### PR TITLE
(bpool) improved benches docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,16 +171,12 @@ Following are latency measurements for allocation across different backends and 
 
 Single tx latency,
 
-| Mode     | N (chunks) | Time (ns / µs) |
-|:---------|:-----------|:---------------|
-| Dynamic  | 1          | 150 ns         |
-| Prealloc | 1          | 262 ns         |
-| Dynamic  | 4          | 163 ns         |
-| Prealloc | 4          | 595 ns         |
-| Dynamic  | 16         | 163 ns         |
-| Prealloc | 16         | 1.97 µs        |
-| Dynamic  | 64         | 220 ns         |
-| Prealloc | 64         | 8.25 µs        |
+| N (Chunks) |  Dynamic Time (ns / µs) | Prealloc Time (ns / µs) |
+|:-----------|:------------------------|:------------------------|
+| 1          | 150 ns                  | 262 ns                  |
+| 4          | 163 ns                  | 595 ns                  |
+| 16         | 163 ns                  | 1.97 µs                 |
+| 64         | 220 ns                  | 8.25 µs                 |
 
 Prealloc scaling (batch size),
 
@@ -212,6 +208,8 @@ Fallback (Prealloc -> Dynamic),
 | 32         | 201 ns    |
 | 64         | 229 ns    |
 | 128        | 252 ns    |
+
+Where value of `N` is `N = 64`.
 
 Environment used for benching,
 

--- a/benches/bpool.rs
+++ b/benches/bpool.rs
@@ -1,5 +1,5 @@
 //! Benchmarks for `bpool` module
-//! Run using: `taskset -c 2 cargo bench --bench bpool --features=bpool`
+//! Run using: `taskset -c 2,3,4 cargo bench --bench bpool --features=bpool`
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use frozen_core::bpool::{BPBackend, BPCfg, BufPool};
@@ -10,14 +10,14 @@ const MID: u8 = 0;
 
 fn new_dynamic() -> BufPool {
     BufPool::new::<MID>(BPCfg {
-        chunk_size: 64,
+        chunk_size: 0x40,
         backend: BPBackend::Dynamic,
     })
 }
 
 fn new_prealloc(cap: usize) -> BufPool {
     BufPool::new::<MID>(BPCfg {
-        chunk_size: 64,
+        chunk_size: 0x40,
         backend: BPBackend::Prealloc { capacity: cap },
     })
 }

--- a/src/bpool.rs
+++ b/src/bpool.rs
@@ -21,16 +21,12 @@
 //! Single tx latency,
 //!
 //! ```md
-//! | Mode     | N (chunks) | Time (ns / µs) |
-//! |:---------|:-----------|:---------------|
-//! | Dynamic  | 1          | 150 ns         |
-//! | Prealloc | 1          | 262 ns         |
-//! | Dynamic  | 4          | 163 ns         |
-//! | Prealloc | 4          | 595 ns         |
-//! | Dynamic  | 16         | 163 ns         |
-//! | Prealloc | 16         | 1.97 µs        |
-//! | Dynamic  | 64         | 220 ns         |
-//! | Prealloc | 64         | 8.25 µs        |
+//! | N (Chunks) |  Dynamic Time (ns / µs) | Prealloc Time (ns / µs) |
+//! |:-----------|:------------------------|:------------------------|
+//! | 1          | 150 ns                  | 262 ns                  |
+//! | 4          | 163 ns                  | 595 ns                  |
+//! | 0x10       | 163 ns                  | 1.97 µs                 |
+//! | 0x40       | 220 ns                  | 8.25 µs                 |
 //! ```
 //!
 //! Prealloc scaling (batch size),
@@ -71,6 +67,8 @@
 //! | 64         | 229 ns    |
 //! | 128        | 252 ns    |
 //! ```
+//!
+//! Where value of `N` is `N = 0x40`.
 //!
 //! Environment used for benching,
 //!


### PR DESCRIPTION
Improved benches docs for `bpool` module

> Added explicit mention of `N` and its value to remove ambiguity