### PR TITLE
Release of `v0.0.23`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ jobs:
             arch: x86_64
           - os: ubuntu-24.04-arm
             arch: aarch64
-          - os: macos-15-intel
-            arch: x86_64
           - os: macos-latest
             arch: aarch64
     runs-on: ${{ matrix.os }}
@@ -42,7 +40,7 @@ jobs:
         run: cargo check --release --all-features
 
       - name: Cargo check (tests)
-        run: cargo check --tests --release --all-features       
+        run: cargo check --tests --release --all-features 
 
   release:
     needs: lints

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,18 +90,12 @@ jobs:
           key: rust-${{ runner.os }}-${{ matrix.arch }}-stable
       - run: cargo test --all-features --release -- --nocapture
 
-  legacy_support:
+  macos_intel:
+    name: MacOs x86
     needs: lints
-    name: Legacy Support
+    runs-on: macos-15-intel
     env:
       RUSTFLAGS: "-D warnings"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-15-intel
-            arch: x86_64
-    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
@@ -111,7 +105,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: rust-${{ runner.os }}-${{ matrix.arch }}-stable
+          key: rust-macos-x86-stable
 
       - name: Cargo check (lib)
         run: cargo check --release --all-features

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,3 +89,32 @@ jobs:
         with:
           key: rust-${{ runner.os }}-${{ matrix.arch }}-stable
       - run: cargo test --all-features --release -- --nocapture
+
+  legacy_support:
+    needs: lints
+    name: Legacy Support
+    env:
+      RUSTFLAGS: "-D warnings"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-${{ runner.os }}-${{ matrix.arch }}-stable
+
+      - name: Cargo check (lib)
+        run: cargo check --release --all-features
+
+      - name: Cargo check (tests)
+        run: cargo check --tests --release --all-features

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,3 +118,25 @@ jobs:
 
       - name: Cargo check (tests)
         run: cargo check --tests --release --all-features
+
+  msrv:
+    name: MSRV (1.85.0)
+    needs: lints
+    runs-on: ubuntu-latest
+  
+    steps:
+      - uses: actions/checkout@v5
+  
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.85.0
+  
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-msrv-1.85.0
+  
+      - name: Check library
+        run: cargo check --all-features --release
+  
+      - name: Check tests
+        run: cargo check --tests --all-features --release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,7 @@ jobs:
         run: cargo check --tests --release --all-features
 
   msrv:
-    name: MSRV (1.85.0)
+    name: MSRV (1.86.0)
     needs: lints
     runs-on: ubuntu-latest
   
@@ -123,7 +123,7 @@ jobs:
   
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.86.0
   
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## `0.0.23`
+
+- Improved `FrozenError` in `error` module
+- Fixed syntax error for bench table in module docs for `bufpool`
+- `ffile`
+  - Renamed `FFCfg` -> `FrozenFileCfg`
+  - Added `module_id` in `FrozenFileCfg`
+  - Migrated to use latest `FrozenError`
+- `fmmap`
+  - Renamed `FMCfg` -> `FrozenMMapCfg`
+  - Added `module_id` in `FrozenMMapCfg`
+  - Migrated to use latest `FrozenError`
+  - Impl of error recovery for lock poisoning on Mutex & RwLock
+
 ## `0.0.22`
 
 - Impl of `wpipe` module (#53)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frozen-core"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2024"
-version = "0.0.22"
+version = "0.0.23"
 name = "frozen-core"
 readme = "README.md"
 rust-version = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 version = "0.0.23"
 name = "frozen-core"
 readme = "README.md"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 description = "Custom implementations and core utilities for frozen-lab crates"
 keywords = [
     "frozen-lab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 edition = "2024"
 version = "0.0.22"
 name = "frozen-core"
-description = "Custom implementations and core utilities for frozen-lab crates"
 readme = "README.md"
+rust-version = "1.85.0"
+description = "Custom implementations and core utilities for frozen-lab crates"
 keywords = [
     "frozen-lab",
     "frozen-core",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add following to your `Cargo.toml`,
 
 ```toml
 [dependencies]
-frozen-core = { version = "0.0.22", default-features = true }
+frozen-core = { version = "0.0.23", default-features = true }
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Add following to your `Cargo.toml`,
 frozen-core = { version = "0.0.23", default-features = true }
 ```
 
+> [!NOTE]
+> Current `frozen-core` requires Rust 1.86 or later.
+
 > [!TIP]
 > All the features are enabled by default. To disable, set `default-features` to `false`.
 

--- a/src/bufpool.rs
+++ b/src/bufpool.rs
@@ -32,24 +32,20 @@
 //!
 //! Observed measurements of latency and throughput,
 //!
-//! ```md
 //! | Metric                       | Value              |
 //! |:-----------------------------|:-------------------|
 //! | Allocation Latency (avg)     | ~254 nanosecond    |
 //! | Allocation Throughput (avg)  | ~3.94 million/sec  |
-//! ```
 //!
 //! _NOTE:_ All measurements includes the complete RAII lifecycle (i.e. allocation + deallocation).
 //!
 //! Observed allocation latency for `N` buffers,
 //!
-//! ```md
 //! | Buffers  | Latency  |
 //! |:---------|:---------|
 //! | 0x01     | 246 ns   |
 //! | 0x10     | 251 ns   |
 //! | 0x400    | 300 ns   |
-//! ```
 //!
 //! _INFO:_ As seen, the allocation latency stays near constant irrespective to the size of buffers
 //! and the allocated bytes.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,12 +19,15 @@
 //! use frozen_core::error::{FrozenError, FrozenResult, ErrCode};
 //!
 //! fn read_file() -> FrozenResult<()> {
-//!     Err(FrozenError::new(1, 2, ErrCode::new(0x0033, "io"), "read failed"))
+//!     Err(FrozenError::new(0x10, 0x20, ErrCode::new(0x30, "io"), "read failed"))
 //! }
 //!
 //! let err = read_file().unwrap_err();
 //!
-//! assert_eq!(err.id, 0x0102_0033);
+//! assert_eq!(err.module, 0x10);
+//! assert_eq!(err.domain, 0x20);
+//! assert_eq!(err.reason, 0x30);
+//!
 //! assert!(err.context.contains("[io]"));
 //! ```
 
@@ -32,10 +35,16 @@
 pub type FrozenResult<T> = Result<T, FrozenError>;
 
 /// Utility for error propagation used across [`frozen_core`]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FrozenError {
-    /// Encoded 32-bit unique identifier for [`FrozenError`]
-    pub id: u32,
+    /// 8-bit unique identifier to identify the _module_ of [`FrozenError`] object
+    pub module: u8,
+
+    /// 8-bit unique identifier to identify the _domain_ of [`FrozenError`] object
+    pub domain: u8,
+
+    /// 8-bit unique identifier to identify the _reason_ of [`FrozenError`] object
+    pub reason: u8,
 
     /// Error context for the [`FrozenError`]
     pub context: String,
@@ -49,15 +58,18 @@ impl FrozenError {
     /// ```
     /// use frozen_core::error::{FrozenError, ErrCode};
     ///
-    /// let err = FrozenError::new(1, 2, ErrCode::new(0x0033, "io"), "failed to read file");
+    /// let err = FrozenError::new(0x10, 0x20, ErrCode::new(0x30, "io"), "failed to read file");
     ///
-    /// assert_eq!(err.id, 0x0102_0033);
+    /// assert_eq!(err.module, 0x10);
+    /// assert_eq!(err.domain, 0x20);
+    /// assert_eq!(err.reason, 0x30);
+    ///
     /// assert!(err.context.contains("[io]"));
     /// assert!(err.context.contains("failed to read file"));
     /// ```
     #[inline(always)]
     pub fn new(module: u8, domain: u8, code: ErrCode, errmsg: &str) -> Self {
-        Self { id: error_id(module, domain, code.reason), context: format!("[{}] {}", code.detail, errmsg) }
+        Self { module, domain, reason: code.reason, context: format!("[{}] {}", code.detail, errmsg) }
     }
 
     /// Construct a new [`FrozenError`] from raw [`Error`] object
@@ -68,15 +80,18 @@ impl FrozenError {
     /// use frozen_core::error::{FrozenError, ErrCode};
     ///
     /// let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
-    /// let err = FrozenError::new_raw(1, 2, ErrCode::new(0x0033, "io"), io_err);
+    /// let err = FrozenError::new_raw(0x14, 0x24, ErrCode::new(0x34, "io"), io_err);
     ///
-    /// assert_eq!(err.id, 0x0102_0033);
+    /// assert_eq!(err.module, 0x14);
+    /// assert_eq!(err.domain, 0x24);
+    /// assert_eq!(err.reason, 0x34);
+    ///
     /// assert!(err.context.contains("[io]"));
     /// assert!(err.context.contains("file missing"));
     /// ```
     #[inline(always)]
     pub fn new_raw<E: std::fmt::Display>(module: u8, domain: u8, code: ErrCode, err: E) -> Self {
-        Self { id: error_id(module, domain, code.reason), context: format!("[{}] {}", code.detail, err) }
+        Self { domain, module, reason: code.reason, context: format!("[{}] {}", code.detail, err) }
     }
 
     /// Compare two errors by their encoded id's
@@ -86,14 +101,30 @@ impl FrozenError {
     /// ```
     /// use frozen_core::error::{FrozenError, ErrCode};
     ///
-    /// let err1 = FrozenError::new(0, 0, ErrCode::new(0x30, "test"), "something failed");
-    /// let err2 = FrozenError::new(0, 0, ErrCode::new(0x30, "test"), "another message");
+    /// let err1 = FrozenError::new(0x1A, 0x2A, ErrCode::new(0x3A, "test"), "something failed");
+    /// let err2 = FrozenError::new(0x1A, 0x2A, ErrCode::new(0x3A, "test"), "another message");
     ///
-    /// assert!(err1.compare_id(&err2));
+    /// assert!(err1.is_equal(&err2));
     /// ```
     #[inline(always)]
-    pub fn compare_id(&self, err: &FrozenError) -> bool {
-        self.id == err.id
+    pub fn is_equal(&self, err: &FrozenError) -> bool {
+        self == err
+    }
+}
+
+impl std::fmt::Debug for FrozenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FrozenError")
+            .field("Module", &self.module)
+            .field("Domain", &self.domain)
+            .field("Reason", &self.reason)
+            .finish()
+    }
+}
+
+impl PartialEq for FrozenError {
+    fn eq(&self, other: &Self) -> bool {
+        (self.module == other.module) && (self.domain == other.domain) && (self.reason == other.reason)
     }
 }
 
@@ -104,15 +135,15 @@ impl FrozenError {
 /// ```
 /// use frozen_core::error::ErrCode;
 ///
-/// const LOCK_ERR: ErrCode = frozen_core::error::ErrCode::new(0x300, "lock error");
+/// const LOCK_ERR: ErrCode = frozen_core::error::ErrCode::new(0xFF, "lock error");
 ///
-/// assert_eq!(LOCK_ERR.reason, 0x300);
+/// assert_eq!(LOCK_ERR.reason, 0xFF);
 /// assert_eq!(LOCK_ERR.detail, "lock error");
 /// ```
 #[derive(Debug, Clone)]
 pub struct ErrCode {
-    /// 16-bit reason code encoded into [`FrozenError::id`]
-    pub reason: u16,
+    /// 8-bit reason code encoded into [`FrozenError::id`]
+    pub reason: u8,
 
     /// Short subsystem label included in the formatted error context
     pub detail: &'static str,
@@ -128,34 +159,20 @@ impl ErrCode {
     /// ```
     /// use frozen_core::error::ErrCode;
     ///
-    /// const LOCK_ERR: ErrCode = frozen_core::error::ErrCode::new(0x300, "lock error");
+    /// const LOCK_ERR: ErrCode = frozen_core::error::ErrCode::new(0xFF, "lock error");
     ///
-    /// assert_eq!(LOCK_ERR.reason, 0x300);
+    /// assert_eq!(LOCK_ERR.reason, 0xFF);
     /// assert_eq!(LOCK_ERR.detail, "lock error");
     /// ```
     #[inline]
-    pub const fn new(reason: u16, detail: &'static str) -> Self {
+    pub const fn new(reason: u8, detail: &'static str) -> Self {
         Self { reason, detail }
     }
-}
-
-#[inline]
-const fn error_id(module: u8, domain: u8, reason: u16) -> u32 {
-    ((module as u32) << 0x18) | ((domain as u32) << 0x10) | (reason as u32)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[inline]
-    const fn from_error_id(eid: u32) -> (u8, u8, u16) {
-        let module = ((eid >> 24) & 0xff) as u8;
-        let domain = ((eid >> 16) & 0xff) as u8;
-        let reason = (eid & 0xffff) as u16;
-
-        (module, domain, reason)
-    }
 
     #[test]
     fn ok_context_exact_format() {
@@ -176,40 +193,13 @@ mod tests {
     }
 
     #[test]
-    fn ok_error_id_roundtrip_basic() {
-        let err = FrozenError::new(0x01, 0x02, ErrCode::new(0x0033, "io"), "read failed");
-        let (m, d, r) = from_error_id(err.id);
-
-        assert_eq!(err.id, 0x0102_0033);
-        assert_eq!((m, d, r), (0x01, 0x02, 0x0033));
-    }
-
-    #[test]
     fn ok_new_and_new_raw_same_id() {
         let e1 = FrozenError::new(1, 2, ErrCode::new(3, "io"), "fail");
 
         let io_err = std::io::Error::new(std::io::ErrorKind::Other, "fail");
         let e2 = FrozenError::new_raw(1, 2, ErrCode::new(3, "io"), io_err);
 
-        assert_eq!(e1.id, e2.id);
-    }
-
-    #[test]
-    fn ok_error_id_roundtrip_edges() {
-        let err = FrozenError::new(0xff, 0x00, ErrCode::new(0xffff, "edge"), "max values");
-        let (m, d, r) = from_error_id(err.id);
-
-        assert_eq!(err.id, 0xff00_ffff);
-        assert_eq!((m, d, r), (0xff, 0x00, 0xffff));
-    }
-
-    #[test]
-    fn ok_error_id_reason_only_changes_low_bits() {
-        let e1 = FrozenError::new(1, 2, ErrCode::new(1, "x"), "a");
-        let e2 = FrozenError::new(1, 2, ErrCode::new(2, "x"), "a");
-
-        assert_eq!(e1.id & 0xffff_0000, e2.id & 0xffff_0000);
-        assert_ne!(e1.id & 0x0000_ffff, e2.id & 0x0000_ffff);
+        assert_eq!(e1, e2);
     }
 
     #[test]
@@ -232,7 +222,7 @@ mod tests {
         let e1 = FrozenError::new(1, 2, ErrCode::new(3, "io"), "a");
         let e2 = FrozenError::new(1, 2, ErrCode::new(3, "io"), "b");
 
-        assert!(e1.compare_id(&e2));
+        assert_eq!(e1, e2);
     }
 
     #[test]
@@ -240,6 +230,6 @@ mod tests {
         let e1 = FrozenError::new(1, 2, ErrCode::new(3, "io"), "a");
         let e2 = FrozenError::new(1, 2, ErrCode::new(4, "io"), "a");
 
-        assert!(!e1.compare_id(&e2));
+        assert_ne!(e1, e2);
     }
 }

--- a/src/ffile/mod.rs
+++ b/src/ffile/mod.rs
@@ -3,14 +3,14 @@
 //! ## Example
 //!
 //! ```
-//! use frozen_core::ffile::{FrozenFile, FFCfg};
+//! use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
 //!
 //! const MID: u8 = 0;
 //!
 //! let dir = tempfile::tempdir().unwrap();
 //! let path = dir.path().join("tmp_frozen_file");
 //!
-//! let cfg = FFCfg {
+//! let cfg = FrozenFileCfg {
 //!     chunk_size: 0x10,
 //!     path: path.to_path_buf(),
 //!     initial_chunk_amount: 0x0A,
@@ -121,7 +121,7 @@ pub(in crate::ffile) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
 
 /// Config for [`FrozenFile`]
 #[derive(Debug, Clone)]
-pub struct FFCfg {
+pub struct FrozenFileCfg {
     /// Absolute path for/of the file
     ///
     /// *NOTE:* The caller must make sure that the path represents a file and all the parent directories included in
@@ -147,14 +147,14 @@ pub struct FFCfg {
 /// ## Example
 ///
 /// ```
-/// use frozen_core::ffile::{FrozenFile, FFCfg};
+/// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
 ///
 /// const MID: u8 = 0;
 ///
 /// let dir = tempfile::tempdir().unwrap();
 /// let path = dir.path().join("tmp_frozen_file");
 ///
-/// let cfg = FFCfg {
+/// let cfg = FrozenFileCfg {
 ///     chunk_size: 0x10,
 ///     path: path.to_path_buf(),
 ///     initial_chunk_amount: 0x0A,
@@ -181,7 +181,7 @@ pub struct FFCfg {
 /// ```
 #[derive(Debug)]
 pub struct FrozenFile {
-    cfg: FFCfg,
+    cfg: FrozenFileCfg,
     file: core::cell::UnsafeCell<core::mem::ManuallyDrop<TFile>>,
 }
 
@@ -209,13 +209,13 @@ impl FrozenFile {
 
     /// Create a new or open an existing [`FrozenFile`]
     ///
-    /// ## [`FFCfg`]
+    /// ## [`FrozenFileCfg`]
     ///
-    /// All configs for [`FrozenFile`] are stored in [`FFCfg`]
+    /// All configs for [`FrozenFile`] are stored in [`FrozenFileCfg`]
     ///
     /// ## Important
     ///
-    /// The provided [`FFCfg`] must remain identical across all reopen cycles of the [`FrozenFile`].
+    /// The provided [`FrozenFileCfg`] must remain identical across all reopen cycles of the [`FrozenFile`].
     ///
     /// Changing any of the feilds after initial creation, may violate internal layout invariants and
     /// cause the file to be treated as corrupted.
@@ -230,14 +230,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -246,7 +246,7 @@ impl FrozenFile {
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
     /// assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
     /// ```
-    pub fn new<const MODULE_ID: u8>(cfg: FFCfg) -> FrozenResult<Self> {
+    pub fn new<const MODULE_ID: u8>(cfg: FrozenFileCfg) -> FrozenResult<Self> {
         let raw_file = unsafe { posix::POSIXFile::new(&cfg.path) }?;
         let slf = Self { cfg: cfg.clone(), file: core::cell::UnsafeCell::new(core::mem::ManuallyDrop::new(raw_file)) };
 
@@ -309,14 +309,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -338,14 +338,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -377,14 +377,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -416,14 +416,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -459,14 +459,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -505,14 +505,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -541,14 +541,14 @@ impl FrozenFile {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::ffile::{FrozenFile, FFCfg};
+    /// use frozen_core::ffile::{FrozenFile, FrozenFileCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_file");
     ///
-    /// let cfg = FFCfg {
+    /// let cfg = FrozenFileCfg {
     ///     chunk_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_chunk_amount: 0x0A,
@@ -607,10 +607,10 @@ mod tests {
     const INIT_CHUNKS: usize = 4;
     const CHUNK_SIZE: usize = 0x10;
 
-    fn tmp_path() -> (tempfile::TempDir, FFCfg) {
+    fn tmp_path() -> (tempfile::TempDir, FrozenFileCfg) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_ff_file");
-        let cfg = FFCfg { path, chunk_size: CHUNK_SIZE, initial_chunk_amount: INIT_CHUNKS };
+        let cfg = FrozenFileCfg { path, chunk_size: CHUNK_SIZE, initial_chunk_amount: INIT_CHUNKS };
 
         (dir, cfg)
     }

--- a/src/ffile/mod.rs
+++ b/src/ffile/mod.rs
@@ -11,9 +11,9 @@
 //! let path = dir.path().join("tmp_frozen_file");
 //!
 //! let cfg = FrozenFileCfg {
-//!     chunk_size: 0x10,
+//!     buffer_size: 0x10,
 //!     path: path.to_path_buf(),
-//!     initial_chunk_amount: 0x0A,
+//!     initial_available_buffers: 0x0A,
 //! };
 //!
 //! let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
@@ -134,12 +134,12 @@ pub struct FrozenFileCfg {
     /// These ops are operated by index of the chunk and not the offset of the byte
     ///
     /// *NOTE:* Chunk size when power of 2, is cache efficient and good for performance
-    pub chunk_size: usize,
+    pub buffer_size: usize,
 
     /// Number of chunks to pre-allocate on fs when [`FrozenFile`] is initialized
     ///
-    /// Initial file length will be `chunk_size * initial_chunk_amount` (bytes)
-    pub initial_chunk_amount: usize,
+    /// Initial file length will be `buffer_size * initial_available_buffers` (bytes)
+    pub initial_available_buffers: usize,
 }
 
 /// Custom implementation of `std::fs::File`
@@ -155,9 +155,9 @@ pub struct FrozenFileCfg {
 /// let path = dir.path().join("tmp_frozen_file");
 ///
 /// let cfg = FrozenFileCfg {
-///     chunk_size: 0x10,
+///     buffer_size: 0x10,
 ///     path: path.to_path_buf(),
-///     initial_chunk_amount: 0x0A,
+///     initial_available_buffers: 0x0A,
 /// };
 ///
 /// let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
@@ -238,9 +238,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -262,19 +262,19 @@ impl FrozenFile {
         let _ = MID.get_or_init(|| MODULE_ID);
 
         let curr_len = slf.length()?;
-        let init_len = cfg.chunk_size * cfg.initial_chunk_amount;
+        let init_len = cfg.buffer_size * cfg.initial_available_buffers;
 
         match curr_len {
-            0 => slf.grow(cfg.initial_chunk_amount)?,
+            0 => slf.grow(cfg.initial_available_buffers)?,
             _ => {
                 // NOTE: we can treat these invariants as errors only because, our system guarantees,
-                // whenever file size is updated, i.e. has grown, it'll always be a multiple of `chunk_size`,
-                // and will have minimum of `chunk_size * initial_chunk_amount` (bytes) as it's length, although
+                // whenever file size is updated, i.e. has grown, it'll always be a multiple of `buffer_size`,
+                // and will have minimum of `buffer_size * initial_available_buffers` (bytes) as it's length, although
                 // it only holds true when any of the params in provided `cfg` are never updated after the initial
                 // creation of the file
                 //
                 // INFO: when true, we close the file to avoid resource leaks
-                if (curr_len < init_len) || (curr_len % cfg.chunk_size != 0) {
+                if (curr_len < init_len) || (curr_len % cfg.buffer_size != 0) {
                     // NOTE: we supress the close error as we are already in an errored state
                     let _ = unsafe { file.close() };
                     return new_err_default(err::CPT);
@@ -297,8 +297,8 @@ impl FrozenFile {
     /// strong sync call i.e. [`FrozenFile::sync`]
     #[cfg(target_os = "linux")]
     pub fn sync_range(&self, index: usize, count: usize) -> FrozenResult<()> {
-        let offset = self.cfg.chunk_size * index;
-        let len_to_sync = self.cfg.chunk_size * count;
+        let offset = self.cfg.buffer_size * index;
+        let len_to_sync = self.cfg.buffer_size * count;
         let file = self.get_file();
 
         unsafe { file.sync_range(offset, len_to_sync) }
@@ -317,9 +317,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -346,9 +346,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -366,10 +366,10 @@ impl FrozenFile {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn pread(&self, buf: *mut u8, index: usize) -> FrozenResult<()> {
-        let offset = self.cfg.chunk_size * index;
+        let offset = self.cfg.buffer_size * index;
         let file = self.get_file();
 
-        unsafe { file.pread(buf, offset, self.cfg.chunk_size) }
+        unsafe { file.pread(buf, offset, self.cfg.buffer_size) }
     }
 
     /// Write a single chunk at given `index` w/ `pwrite` syscall
@@ -385,9 +385,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -405,10 +405,10 @@ impl FrozenFile {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn pwrite(&self, buf: *mut u8, index: usize) -> FrozenResult<()> {
-        let offset = self.cfg.chunk_size * index;
+        let offset = self.cfg.buffer_size * index;
         let file = self.get_file();
 
-        unsafe { file.pwrite(buf, offset, self.cfg.chunk_size) }
+        unsafe { file.pwrite(buf, offset, self.cfg.buffer_size) }
     }
 
     /// Read multiple chunks starting from given `index` till `bufs.len()` w/ `preadv` syscall
@@ -424,9 +424,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -448,10 +448,10 @@ impl FrozenFile {
     #[inline(always)]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn preadv(&self, bufs: &[*mut u8], index: usize) -> FrozenResult<()> {
-        let offset = self.cfg.chunk_size * index;
+        let offset = self.cfg.buffer_size * index;
         let file = self.get_file();
 
-        unsafe { file.preadv(bufs, offset, self.cfg.chunk_size) }
+        unsafe { file.preadv(bufs, offset, self.cfg.buffer_size) }
     }
 
     /// Write multiple chunks starting from given `index` till `bufs.len()` w/ `pwritev` syscall
@@ -467,9 +467,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -492,15 +492,15 @@ impl FrozenFile {
     #[inline(always)]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn pwritev(&self, bufs: &[*mut u8], index: usize) -> FrozenResult<()> {
-        let offset = self.cfg.chunk_size * index;
+        let offset = self.cfg.buffer_size * index;
         let file = self.get_file();
 
-        unsafe { file.pwritev(bufs, offset, self.cfg.chunk_size) }
+        unsafe { file.pwritev(bufs, offset, self.cfg.buffer_size) }
     }
 
     /// Grow file size of [`FrozenFile`] by given `count` of chunks
     ///
-    /// After successful execution, updated file length will be `current_length + (count * chunk_size)`
+    /// After successful execution, updated file length will be `current_length + (count * buffer_size)`
     ///
     /// ## Example
     ///
@@ -513,9 +513,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -526,7 +526,7 @@ impl FrozenFile {
     /// ```
     pub fn grow(&self, count: usize) -> FrozenResult<()> {
         let curr_len = self.length()?;
-        let len_to_add = self.cfg.chunk_size * count;
+        let len_to_add = self.cfg.buffer_size * count;
 
         unsafe { self.get_file().grow(curr_len, len_to_add) }
     }
@@ -549,9 +549,9 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
-    ///     chunk_size: 0x10,
+    ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
-    ///     initial_chunk_amount: 0x0A,
+    ///     initial_available_buffers: 0x0A,
     /// };
     ///
     /// let file = FrozenFile::new::<MID>(cfg).unwrap();
@@ -563,13 +563,13 @@ impl FrozenFile {
     #[inline]
     pub fn total_chunks(&self) -> FrozenResult<usize> {
         let curr_len = self.length()?;
-        let chunk_size = self.cfg.chunk_size;
+        let buffer_size = self.cfg.buffer_size;
 
-        if crate::hints::unlikely(curr_len % chunk_size != 0) {
+        if crate::hints::unlikely(curr_len % buffer_size != 0) {
             return new_err_default(err::CPT);
         }
 
-        Ok(curr_len / chunk_size)
+        Ok(curr_len / buffer_size)
     }
 
     #[inline]
@@ -601,16 +601,16 @@ impl core::fmt::Display for FrozenFile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync;
 
     const MID: u8 = 0;
-    const INIT_CHUNKS: usize = 4;
-    const CHUNK_SIZE: usize = 0x10;
+    const INIT_BUFFERS: usize = 4;
+    const BUFFER_SIZE: usize = 0x10;
 
     fn tmp_path() -> (tempfile::TempDir, FrozenFileCfg) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_ff_file");
-        let cfg = FrozenFileCfg { path, chunk_size: CHUNK_SIZE, initial_chunk_amount: INIT_CHUNKS };
+        let cfg = FrozenFileCfg { path, buffer_size: BUFFER_SIZE, initial_available_buffers: INIT_BUFFERS };
 
         (dir, cfg)
     }
@@ -626,7 +626,7 @@ mod tests {
             let exists = file.exists().unwrap();
             assert!(exists);
 
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * INIT_CHUNKS);
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
         }
 
         #[test]
@@ -634,13 +634,13 @@ mod tests {
             let (_dir, cfg) = tmp_path();
 
             let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * INIT_CHUNKS);
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
 
             // must be dropped to release the exclusive lock
             drop(file);
 
             let reopened = FrozenFile::new::<MID>(cfg.clone()).unwrap();
-            assert_eq!(reopened.length().unwrap(), CHUNK_SIZE * INIT_CHUNKS);
+            assert_eq!(reopened.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
         }
 
         #[test]
@@ -651,7 +651,7 @@ mod tests {
             drop(file);
 
             // updated cfg
-            cfg.chunk_size *= 2;
+            cfg.buffer_size *= 2;
 
             let err = FrozenFile::new::<MID>(cfg).unwrap_err();
             assert_eq!((err.id & 0xffff) as u16, err::CPT.reason);
@@ -702,7 +702,7 @@ mod tests {
 
         #[test]
         fn ok_drop_persists_without_explicit_sync() {
-            let mut data = [0x0Bu8; CHUNK_SIZE];
+            let mut data = [0x0Bu8; BUFFER_SIZE];
             let (_dir, cfg) = tmp_path();
 
             {
@@ -713,7 +713,7 @@ mod tests {
 
             {
                 let reopened = FrozenFile::new::<MID>(cfg).unwrap();
-                let mut buf = [0u8; CHUNK_SIZE];
+                let mut buf = [0u8; BUFFER_SIZE];
 
                 reopened.pread(buf.as_mut_ptr(), 0).unwrap();
                 assert_eq!(buf, data);
@@ -754,10 +754,10 @@ mod tests {
             let (_dir, cfg) = tmp_path();
 
             let file = FrozenFile::new::<MID>(cfg).unwrap();
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * INIT_CHUNKS);
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
 
             file.grow(0x20).unwrap();
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * (INIT_CHUNKS + 0x20));
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * (INIT_BUFFERS + 0x20));
         }
 
         #[test]
@@ -770,7 +770,7 @@ mod tests {
                 file.sync().unwrap();
             }
 
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * (INIT_CHUNKS + (0x0A * 0x100)));
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * (INIT_BUFFERS + (0x0A * 0x100)));
         }
     }
 
@@ -806,12 +806,12 @@ mod tests {
             let (_dir, cfg) = tmp_path();
             let file = FrozenFile::new::<MID>(cfg).unwrap();
 
-            let mut data = [0x0Bu8; CHUNK_SIZE];
+            let mut data = [0x0Bu8; BUFFER_SIZE];
 
             file.pwrite(data.as_mut_ptr(), 4).unwrap();
             file.sync().unwrap();
 
-            let mut buf = [0u8; CHUNK_SIZE];
+            let mut buf = [0u8; BUFFER_SIZE];
             file.pread(buf.as_mut_ptr(), 4).unwrap();
             assert_eq!(buf, data);
         }
@@ -821,13 +821,13 @@ mod tests {
             let (_dir, cfg) = tmp_path();
             let file = FrozenFile::new::<MID>(cfg).unwrap();
 
-            let mut bufs = [[1u8; CHUNK_SIZE], [2u8; CHUNK_SIZE]];
+            let mut bufs = [[1u8; BUFFER_SIZE], [2u8; BUFFER_SIZE]];
             let bufs: Vec<*mut u8> = bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
 
             file.pwritev(&bufs, 0).unwrap();
             file.sync().unwrap();
 
-            let mut read_bufs = [[0u8; CHUNK_SIZE], [0u8; CHUNK_SIZE]];
+            let mut read_bufs = [[0u8; BUFFER_SIZE], [0u8; BUFFER_SIZE]];
             let rbufs: Vec<*mut u8> = read_bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
             file.preadv(&rbufs, 0).unwrap();
 
@@ -838,14 +838,14 @@ mod tests {
         #[test]
         fn ok_write_concurrent_non_overlapping() {
             let (_dir, mut cfg) = tmp_path();
-            cfg.initial_chunk_amount = 0x100;
-            let file = Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            cfg.initial_available_buffers = 0x100;
+            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
 
             let mut handles = vec![];
             for i in 0..2 {
                 let f = file.clone();
                 handles.push(std::thread::spawn(move || {
-                    let mut data = [i as u8; CHUNK_SIZE];
+                    let mut data = [i as u8; BUFFER_SIZE];
                     f.pwrite(data.as_mut_ptr(), i).unwrap();
                 }));
             }
@@ -857,7 +857,7 @@ mod tests {
             file.sync().unwrap();
 
             for i in 0..2 {
-                let mut buf = [0u8; CHUNK_SIZE];
+                let mut buf = [0u8; BUFFER_SIZE];
                 file.pread(buf.as_mut_ptr(), i).unwrap();
                 assert!(buf.iter().all(|b| *b == i as u8));
             }
@@ -866,13 +866,13 @@ mod tests {
         #[test]
         fn ok_concurrent_grow_and_write() {
             let (_dir, cfg) = tmp_path();
-            let file = Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
 
             let writer = {
                 let f = file.clone();
                 std::thread::spawn(move || {
-                    for i in 0..INIT_CHUNKS {
-                        let mut data = [i as u8; CHUNK_SIZE];
+                    for i in 0..INIT_BUFFERS {
+                        let mut data = [i as u8; BUFFER_SIZE];
                         f.pwrite(data.as_mut_ptr(), i).unwrap();
                     }
                 })
@@ -890,10 +890,10 @@ mod tests {
             grower.join().unwrap();
 
             file.sync().unwrap();
-            assert_eq!(file.length().unwrap(), CHUNK_SIZE * (INIT_CHUNKS + chunks_to_grow));
+            assert_eq!(file.length().unwrap(), BUFFER_SIZE * (INIT_BUFFERS + chunks_to_grow));
 
-            for i in 0..INIT_CHUNKS {
-                let mut buf = [0u8; CHUNK_SIZE];
+            for i in 0..INIT_BUFFERS {
+                let mut buf = [0u8; BUFFER_SIZE];
                 file.pread(buf.as_mut_ptr(), i).unwrap();
                 assert!(buf.iter().all(|b| *b == i as u8));
             }
@@ -902,13 +902,13 @@ mod tests {
         #[test]
         fn ok_concurrent_sync_and_write() {
             let (_dir, cfg) = tmp_path();
-            let file = Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
 
             let writer = {
                 let f = file.clone();
                 std::thread::spawn(move || {
-                    for i in 0..INIT_CHUNKS {
-                        let mut data = [i as u8; CHUNK_SIZE];
+                    for i in 0..INIT_BUFFERS {
+                        let mut data = [i as u8; BUFFER_SIZE];
                         f.pwrite(data.as_mut_ptr(), i).unwrap();
                     }
                 })
@@ -928,8 +928,8 @@ mod tests {
 
             file.sync().unwrap();
 
-            for i in 0..INIT_CHUNKS {
-                let mut buf = [0; CHUNK_SIZE];
+            for i in 0..INIT_BUFFERS {
+                let mut buf = [0; BUFFER_SIZE];
                 file.pread(buf.as_mut_ptr(), i).unwrap();
                 assert!(buf.iter().all(|b| *b == i as u8));
             }
@@ -941,7 +941,7 @@ mod tests {
             let file = FrozenFile::new::<MID>(cfg).unwrap();
 
             // index > curr_chunks
-            let mut buf = [0; CHUNK_SIZE];
+            let mut buf = [0; BUFFER_SIZE];
             let err = file.pread(buf.as_mut_ptr(), 0x100).unwrap_err();
             assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
         }

--- a/src/ffile/mod.rs
+++ b/src/ffile/mod.rs
@@ -40,10 +40,7 @@
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod posix;
 
-use crate::error::{ErrCode, FrozenError, FrozenResult};
-
-/// Domain Id for [`FrozenFile`] is **17**
-const ERRDOMAIN: u8 = 0x11;
+use crate::error::FrozenResult;
 
 /// File descriptor of [`FrozenFile`]
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -52,72 +49,75 @@ pub type TFileId = libc::c_int;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 type TFile = posix::POSIXFile;
 
-/// module id used for [`FrozenError`]
-static MID: std::sync::OnceLock<u8> = std::sync::OnceLock::new();
-
-#[cfg(not(test))]
-#[inline(always)]
-fn mid() -> &'static u8 {
-    MID.get().unwrap()
-}
-
-#[cfg(test)]
-#[inline(always)]
-fn mid() -> &'static u8 {
-    MID.get_or_init(|| 0)
-}
-
 /// Error codes for [`FrozenFile`]
 pub(in crate::ffile) mod err {
-    use super::ErrCode;
+    use crate::error::{ErrCode, FrozenError, FrozenResult};
 
-    /// (256) internal fuck up (hault and catch fire)
-    pub const HCF: ErrCode = ErrCode::new(0x100, "hault and catch fire");
+    /// Domain Id for [`FrozenFile`] is **17**
+    const ERRDOMAIN: u8 = 0x11;
 
-    /// (257) unknown error (fallback)
-    pub const UNK: ErrCode = ErrCode::new(0x101, "unknown error");
+    /// module id used for [`FrozenError`]
+    pub static MID: std::sync::OnceLock<u8> = std::sync::OnceLock::new();
 
-    /// (258) no more space available
-    pub const NSP: ErrCode = ErrCode::new(0x102, "not enough space available on the storage device");
+    #[cfg(not(test))]
+    #[inline(always)]
+    pub fn mid() -> &'static u8 {
+        MID.get().unwrap()
+    }
 
-    /// (259) syncing error
-    pub const SYN: ErrCode = ErrCode::new(0x103, "failed to sync/flush data to storage device");
+    #[cfg(test)]
+    #[inline(always)]
+    pub fn mid() -> &'static u8 {
+        MID.get_or_init(|| 0)
+    }
 
-    /// (260) no write perm
-    pub const WRT: ErrCode = ErrCode::new(0x104, "missing permissions for write");
+    /// internal fuck up (hault and catch fire)
+    pub const HCF: ErrCode = ErrCode::new(0x02, "hault and catch fire");
 
-    /// (261) no read perm
-    pub const RED: ErrCode = ErrCode::new(0x105, "missing permissions for read");
+    /// unknown error (fallback)
+    pub const UNK: ErrCode = ErrCode::new(0x04, "unknown error");
 
-    /// (262) invalid file path
-    pub const INV: ErrCode = ErrCode::new(0x106, "invalid path to file");
+    /// no more space available
+    pub const NSP: ErrCode = ErrCode::new(0x08, "not enough space available on the storage device");
 
-    /// (263) corrupted file
-    pub const CPT: ErrCode = ErrCode::new(0x107, "file is either invalid or corrupted");
+    /// syncing error
+    pub const SYN: ErrCode = ErrCode::new(0x0A, "failed to sync/flush data to storage device");
 
-    /// (264) unable to grow
-    pub const GRW: ErrCode = ErrCode::new(0x108, "unable to zero-extend file");
+    /// no write perm
+    pub const WRT: ErrCode = ErrCode::new(0x0C, "missing permissions for write");
 
-    /// (265) unable to obtain exclusive lock
-    pub const LCK: ErrCode = ErrCode::new(0x109, "failed to obtain exclusive lock as file may already opened");
+    /// no read perm
+    pub const RED: ErrCode = ErrCode::new(0x0E, "missing permissions for read");
 
-    /// (266) locks exhausted (mainly on nfs)
-    pub const LEX: ErrCode = ErrCode::new(0x10A, "failed to obtain lock, as no more locks available");
+    /// invalid file path
+    pub const INV: ErrCode = ErrCode::new(0x10, "invalid path to file");
 
-    /// (267) no write/read perm
-    pub const PRM: ErrCode = ErrCode::new(0x10B, "missing permissions for IO");
-}
+    /// corrupted file
+    pub const CPT: ErrCode = ErrCode::new(0x12, "file is either invalid or corrupted");
 
-#[inline]
-pub(in crate::ffile) fn new_err<R, E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenResult<R> {
-    let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, error);
-    Err(err)
-}
+    /// unable to grow
+    pub const GRW: ErrCode = ErrCode::new(0x14, "unable to zero-extend file");
 
-#[inline]
-pub(in crate::ffile) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
-    let err = FrozenError::new(*mid(), ERRDOMAIN, code, "");
-    Err(err)
+    /// locks exhausted (mainly on nfs)
+    pub const LEX: ErrCode = ErrCode::new(0x18, "failed to obtain lock, as no more locks available");
+
+    /// no write/read perm
+    pub const PRM: ErrCode = ErrCode::new(0x1A, "missing permissions for IO");
+
+    /// unable to obtain exclusive lock
+    pub const LCK: ErrCode = ErrCode::new(0x1C, "failed to obtain exclusive lock as file may already opened");
+
+    #[inline]
+    pub(in crate::ffile) fn new_err<R, E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenResult<R> {
+        let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, error);
+        Err(err)
+    }
+
+    #[inline]
+    pub(in crate::ffile) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
+        let err = FrozenError::new(*mid(), ERRDOMAIN, code, "");
+        Err(err)
+    }
 }
 
 /// Config for [`FrozenFile`]
@@ -128,21 +128,22 @@ pub struct FrozenFileCfg {
 
     /// Absolute path for/of the file
     ///
-    /// *NOTE:* The caller must make sure that the path represents a file and all the parent directories included in
-    /// the path do exists
+    /// *NOTE:* The caller must make sure that the path represents a file and all the parent
+    /// directories included in the path do exists.
     pub path: std::path::PathBuf,
 
     /// Size (in bytes) of a single chunk in file
     ///
-    /// A chunk is a small fixed size allocation and addressing unit used by [`FrozenFile`] for all the write/read ops.
-    /// These ops are operated by index of the chunk and not the offset of the byte
+    /// A chunk is a small fixed size allocation and addressing unit used by [`FrozenFile`] for all
+    /// the write/read ops. These ops are operated by index of the chunk and not the offset of the
+    /// byte.
     ///
     /// *NOTE:* Chunk size when power of 2, is cache efficient and good for performance
     pub buffer_size: usize,
 
     /// Number of chunks to pre-allocate on fs when [`FrozenFile`] is initialized
     ///
-    /// Initial file length will be `buffer_size * initial_available_buffers` (bytes)
+    /// Initial file length will be `buffer_size * initial_available_buffers` (bytes).
     pub initial_available_buffers: usize,
 }
 
@@ -220,17 +221,19 @@ impl FrozenFile {
     ///
     /// ## Important
     ///
-    /// The provided [`FrozenFileCfg`] must remain identical across all reopen cycles of the [`FrozenFile`].
+    /// The provided [`FrozenFileCfg`] must remain identical across all reopen cycles of the
+    /// [`FrozenFile`].
     ///
-    /// Changing any of the feilds after initial creation, may violate internal layout invariants and
-    /// cause the file to be treated as corrupted.
+    /// Changing any of the feilds after initial creation, may violate internal layout invariants
+    /// and cause the file to be treated as corrupted.
     ///
     /// ## Multiple Instances
     ///
-    /// Every instance of [`FrozenFile`] tries to acquire an exclusive lock, which protects against operating with
-    /// multiple simultenious instances.
+    /// Every instance of [`FrozenFile`] tries to acquire an exclusive lock, which protects against
+    /// operating with multiple simultenious instances.
     ///
-    /// If trying to call [`FrozenFile::new`] when already called, [`FFileErr::Lck`] error will be thrown.
+    /// If trying to call [`FrozenFile::new`] when already called, [`FFileErr::Lck`] error will be
+    /// thrown.
     ///
     /// ## Example
     ///
@@ -258,14 +261,14 @@ impl FrozenFile {
 
         let file = slf.get_file();
 
-        // INFO: right after open is successful, we must obtain an exclusive lock on the entire file. So the
-        // another instance of [`FrozenFile`] will try to access the same lock, would correctly fail with
-        // [`FFileErr::Lck`] error.
+        // INFO: right after open is successful, we must obtain an exclusive lock on the entire file.
+        // So the another instance of [`FrozenFile`] will try to access the same lock, would
+        // correctly fail with [`FFileErr::Lck`] error.
         unsafe { file.flock() }?;
 
-        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
-        // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| cfg.module_id);
+        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock`
+        // guarantees that the first caller sets the value and all subsequent calls reuse it
+        let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let curr_len = slf.length()?;
         let init_len = cfg.buffer_size * cfg.initial_available_buffers;
@@ -274,16 +277,16 @@ impl FrozenFile {
             0 => slf.grow(cfg.initial_available_buffers)?,
             _ => {
                 // NOTE: we can treat these invariants as errors only because, our system guarantees,
-                // whenever file size is updated, i.e. has grown, it'll always be a multiple of `buffer_size`,
-                // and will have minimum of `buffer_size * initial_available_buffers` (bytes) as it's length, although
-                // it only holds true when any of the params in provided `cfg` are never updated after the initial
-                // creation of the file
+                // whenever file size is updated, i.e. has grown, it'll always be a multiple of
+                // `buffer_size`, and will have minimum of `buffer_size * initial_available_buffers`
+                // (bytes) as it's length, although it only holds true when any of the params in
+                // provided `cfg` are never updated after the initial creation of the file
                 //
                 // INFO: when true, we close the file to avoid resource leaks
                 if (curr_len < init_len) || (curr_len % cfg.buffer_size != 0) {
                     // NOTE: we supress the close error as we are already in an errored state
                     let _ = unsafe { file.close() };
-                    return new_err_default(err::CPT);
+                    return err::new_err_default(err::CPT);
                 }
             }
         }
@@ -299,8 +302,8 @@ impl FrozenFile {
 
     /// A best-effort call to prompt kernel to start flushing dirty pages in the specified range
     ///
-    /// This call, by itself, does not guarantee any kind of durability, and must always be paired with
-    /// strong sync call i.e. [`FrozenFile::sync`]
+    /// This call, by itself, does not guarantee any kind of durability, and must always be paired
+    /// with strong sync call i.e. [`FrozenFile::sync`]
     #[cfg(target_os = "linux")]
     pub fn sync_range(&self, index: usize, count: usize) -> FrozenResult<()> {
         let offset = self.cfg.buffer_size * index;
@@ -547,8 +550,9 @@ impl FrozenFile {
     ///
     /// ## Working
     ///
-    /// This call performs a syscall to fetch current length of [`FrozenFile`] from fs, as the current length of the
-    /// file is not cached anywhere in the pipeline to avoid TOCTAU race conditions
+    /// This call performs a syscall to fetch current length of [`FrozenFile`] from fs, as the
+    /// current length of the file is not cached anywhere in the pipeline to avoid TOCTAU race
+    /// conditions.
     ///
     /// ## Example
     ///
@@ -579,7 +583,7 @@ impl FrozenFile {
         let buffer_size = self.cfg.buffer_size;
 
         if crate::hints::unlikely(curr_len % buffer_size != 0) {
-            return new_err_default(err::CPT);
+            return err::new_err_default(err::CPT);
         }
 
         Ok(curr_len / buffer_size)
@@ -668,7 +672,7 @@ mod tests {
             cfg.buffer_size *= 2;
 
             let err = FrozenFile::new(cfg).unwrap_err();
-            assert_eq!((err.id & 0xffff) as u16, err::CPT.reason);
+            assert_eq!(err.reason, err::CPT.reason);
         }
 
         #[test]
@@ -711,7 +715,7 @@ mod tests {
             file.delete().unwrap();
 
             let err = file.delete().unwrap_err();
-            assert_eq!((err.id & 0xffff) as u16, err::INV.reason);
+            assert_eq!(err.reason, err::INV.reason);
         }
 
         #[test]
@@ -744,7 +748,7 @@ mod tests {
             let file = FrozenFile::new(cfg.clone()).unwrap();
 
             let err = FrozenFile::new(cfg).unwrap_err();
-            assert_eq!((err.id & 0xffff) as u16, err::LCK.reason);
+            assert_eq!(err.reason, err::LCK.reason);
 
             drop(file);
         }
@@ -808,7 +812,7 @@ mod tests {
             file.delete().unwrap();
 
             let err = file.sync().unwrap_err();
-            assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+            assert_eq!(err.reason, err::HCF.reason);
         }
     }
 
@@ -957,7 +961,7 @@ mod tests {
             // index > curr_chunks
             let mut buf = [0; BUFFER_SIZE];
             let err = file.pread(buf.as_mut_ptr(), 0x100).unwrap_err();
-            assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+            assert_eq!(err.reason, err::HCF.reason);
         }
     }
 }

--- a/src/ffile/mod.rs
+++ b/src/ffile/mod.rs
@@ -11,12 +11,13 @@
 //! let path = dir.path().join("tmp_frozen_file");
 //!
 //! let cfg = FrozenFileCfg {
+//!     module_id: MID,
 //!     buffer_size: 0x10,
 //!     path: path.to_path_buf(),
 //!     initial_available_buffers: 0x0A,
 //! };
 //!
-//! let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+//! let file = FrozenFile::new(cfg.clone()).unwrap();
 //! assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
 //!
 //! let mut data = vec![1u8; 0x10];
@@ -27,13 +28,13 @@
 //! assert!(file.pread(buf.as_mut_ptr(), 0).is_ok());
 //! assert_eq!(buf, data);
 //!
-//! assert!(FrozenFile::new::<MID>(cfg.clone()).is_err());
+//! assert!(FrozenFile::new(cfg.clone()).is_err());
 //!
 //! assert!(file.delete().is_ok());
 //! assert!(!path.exists());
 //!
 //! drop(file);
-//! assert!(FrozenFile::new::<MID>(cfg).is_ok());
+//! assert!(FrozenFile::new(cfg).is_ok());
 //! ```
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -122,6 +123,9 @@ pub(in crate::ffile) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
 /// Config for [`FrozenFile`]
 #[derive(Debug, Clone)]
 pub struct FrozenFileCfg {
+    /// Identifier used for error propagation by [`frozen_core::error::FrozenError`]
+    pub module_id: u8,
+
     /// Absolute path for/of the file
     ///
     /// *NOTE:* The caller must make sure that the path represents a file and all the parent directories included in
@@ -155,12 +159,13 @@ pub struct FrozenFileCfg {
 /// let path = dir.path().join("tmp_frozen_file");
 ///
 /// let cfg = FrozenFileCfg {
+///     module_id: MID,
 ///     buffer_size: 0x10,
 ///     path: path.to_path_buf(),
 ///     initial_available_buffers: 0x0A,
 /// };
 ///
-/// let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+/// let file = FrozenFile::new(cfg.clone()).unwrap();
 /// assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
 ///
 /// let mut data = vec![1u8; 0x10];
@@ -171,13 +176,13 @@ pub struct FrozenFileCfg {
 /// assert!(file.pread(buf.as_mut_ptr(), 0).is_ok());
 /// assert_eq!(buf, data);
 ///
-/// assert!(FrozenFile::new::<MID>(cfg.clone()).is_err());
+/// assert!(FrozenFile::new(cfg.clone()).is_err());
 ///
 /// assert!(file.delete().is_ok());
 /// assert!(!path.exists());
 ///
 /// drop(file);
-/// assert!(FrozenFile::new::<MID>(cfg).is_ok());
+/// assert!(FrozenFile::new(cfg).is_ok());
 /// ```
 #[derive(Debug)]
 pub struct FrozenFile {
@@ -238,15 +243,16 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     /// assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
     /// ```
-    pub fn new<const MODULE_ID: u8>(cfg: FrozenFileCfg) -> FrozenResult<Self> {
+    pub fn new(cfg: FrozenFileCfg) -> FrozenResult<Self> {
         let raw_file = unsafe { posix::POSIXFile::new(&cfg.path) }?;
         let slf = Self { cfg: cfg.clone(), file: core::cell::UnsafeCell::new(core::mem::ManuallyDrop::new(raw_file)) };
 
@@ -259,7 +265,7 @@ impl FrozenFile {
 
         // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
         // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| MODULE_ID);
+        let _ = MID.get_or_init(|| cfg.module_id);
 
         let curr_len = slf.length()?;
         let init_len = cfg.buffer_size * cfg.initial_available_buffers;
@@ -317,12 +323,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     /// assert!(file.exists().unwrap());
     ///
     /// file.delete().unwrap();
@@ -346,12 +353,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     ///
     /// let mut data = [7u8; 0x10];
     /// file.pwrite(data.as_mut_ptr(), 2).unwrap();
@@ -385,12 +393,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     ///
     /// let mut data = [9u8; 0x10];
     /// file.pwrite(data.as_mut_ptr(), 4).unwrap();
@@ -424,12 +433,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     ///
     /// let mut write_bufs = [[1u8; 0x10], [2u8; 0x10]];
     /// let ptrs: Vec<*mut u8> = write_bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
@@ -467,12 +477,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     ///
     /// let mut bufs = [[3u8; 0x10], [4u8; 0x10]];
     /// let ptrs: Vec<*mut u8> = bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
@@ -513,12 +524,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     /// assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
     ///
     /// file.grow(0x20).unwrap();
@@ -549,12 +561,13 @@ impl FrozenFile {
     /// let path = dir.path().join("tmp_frozen_file");
     ///
     /// let cfg = FrozenFileCfg {
+    ///     module_id: MID,
     ///     buffer_size: 0x10,
     ///     path: path.to_path_buf(),
     ///     initial_available_buffers: 0x0A,
     /// };
     ///
-    /// let file = FrozenFile::new::<MID>(cfg).unwrap();
+    /// let file = FrozenFile::new(cfg).unwrap();
     /// assert_eq!(file.length().unwrap(), 0x10 * 0x0A);
     ///
     /// file.grow(0x20).unwrap();
@@ -610,7 +623,8 @@ mod tests {
     fn tmp_path() -> (tempfile::TempDir, FrozenFileCfg) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_ff_file");
-        let cfg = FrozenFileCfg { path, buffer_size: BUFFER_SIZE, initial_available_buffers: INIT_BUFFERS };
+        let cfg =
+            FrozenFileCfg { path, module_id: MID, buffer_size: BUFFER_SIZE, initial_available_buffers: INIT_BUFFERS };
 
         (dir, cfg)
     }
@@ -621,7 +635,7 @@ mod tests {
         #[test]
         fn ok_new_with_init_len() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             let exists = file.exists().unwrap();
             assert!(exists);
@@ -633,13 +647,13 @@ mod tests {
         fn ok_new_existing() {
             let (_dir, cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+            let file = FrozenFile::new(cfg.clone()).unwrap();
             assert_eq!(file.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
 
             // must be dropped to release the exclusive lock
             drop(file);
 
-            let reopened = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+            let reopened = FrozenFile::new(cfg.clone()).unwrap();
             assert_eq!(reopened.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
         }
 
@@ -647,20 +661,20 @@ mod tests {
         fn err_new_when_file_smaller_than_init_len() {
             let (_dir, mut cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+            let file = FrozenFile::new(cfg.clone()).unwrap();
             drop(file);
 
             // updated cfg
             cfg.buffer_size *= 2;
 
-            let err = FrozenFile::new::<MID>(cfg).unwrap_err();
+            let err = FrozenFile::new(cfg).unwrap_err();
             assert_eq!((err.id & 0xffff) as u16, err::CPT.reason);
         }
 
         #[test]
         fn ok_exists_true_when_exists() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             let exists = file.exists().unwrap();
             assert!(exists);
@@ -669,7 +683,7 @@ mod tests {
         #[test]
         fn ok_exists_false_when_missing() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
             file.delete().unwrap();
 
             let exists = file.exists().unwrap();
@@ -680,7 +694,7 @@ mod tests {
         fn ok_delete_file() {
             let (_dir, cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
             let exists = file.exists().unwrap();
             assert!(exists);
 
@@ -693,7 +707,7 @@ mod tests {
         fn err_delete_after_delete() {
             let (_dir, cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
             file.delete().unwrap();
 
             let err = file.delete().unwrap_err();
@@ -706,13 +720,13 @@ mod tests {
             let (_dir, cfg) = tmp_path();
 
             {
-                let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+                let file = FrozenFile::new(cfg.clone()).unwrap();
                 file.pwrite(data.as_mut_ptr(), 0).unwrap();
                 drop(file);
             }
 
             {
-                let reopened = FrozenFile::new::<MID>(cfg).unwrap();
+                let reopened = FrozenFile::new(cfg).unwrap();
                 let mut buf = [0u8; BUFFER_SIZE];
 
                 reopened.pread(buf.as_mut_ptr(), 0).unwrap();
@@ -727,9 +741,9 @@ mod tests {
         #[test]
         fn err_new_when_already_open() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+            let file = FrozenFile::new(cfg.clone()).unwrap();
 
-            let err = FrozenFile::new::<MID>(cfg).unwrap_err();
+            let err = FrozenFile::new(cfg).unwrap_err();
             assert_eq!((err.id & 0xffff) as u16, err::LCK.reason);
 
             drop(file);
@@ -739,10 +753,10 @@ mod tests {
         fn ok_drop_releases_exclusive_lock() {
             let (_dir, cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg.clone()).unwrap();
+            let file = FrozenFile::new(cfg.clone()).unwrap();
             drop(file);
 
-            let _ = FrozenFile::new::<MID>(cfg).expect("must not fail after drop");
+            let _ = FrozenFile::new(cfg).expect("must not fail after drop");
         }
     }
 
@@ -753,7 +767,7 @@ mod tests {
         fn ok_grow_updates_length() {
             let (_dir, cfg) = tmp_path();
 
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
             assert_eq!(file.length().unwrap(), BUFFER_SIZE * INIT_BUFFERS);
 
             file.grow(0x20).unwrap();
@@ -763,7 +777,7 @@ mod tests {
         #[test]
         fn ok_grow_sync_cycle() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             for _ in 0..0x0A {
                 file.grow(0x100).unwrap();
@@ -780,7 +794,7 @@ mod tests {
         #[test]
         fn ok_sync_after_sync() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             file.sync().unwrap();
             file.sync().unwrap();
@@ -790,7 +804,7 @@ mod tests {
         #[test]
         fn err_sync_after_delete() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
             file.delete().unwrap();
 
             let err = file.sync().unwrap_err();
@@ -804,7 +818,7 @@ mod tests {
         #[test]
         fn ok_single_write_read_cycle() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             let mut data = [0x0Bu8; BUFFER_SIZE];
 
@@ -819,7 +833,7 @@ mod tests {
         #[test]
         fn ok_vectored_write_read_cycle() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             let mut bufs = [[1u8; BUFFER_SIZE], [2u8; BUFFER_SIZE]];
             let bufs: Vec<*mut u8> = bufs.iter_mut().map(|b| b.as_mut_ptr()).collect();
@@ -839,7 +853,7 @@ mod tests {
         fn ok_write_concurrent_non_overlapping() {
             let (_dir, mut cfg) = tmp_path();
             cfg.initial_available_buffers = 0x100;
-            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            let file = sync::Arc::new(FrozenFile::new(cfg).unwrap());
 
             let mut handles = vec![];
             for i in 0..2 {
@@ -866,7 +880,7 @@ mod tests {
         #[test]
         fn ok_concurrent_grow_and_write() {
             let (_dir, cfg) = tmp_path();
-            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            let file = sync::Arc::new(FrozenFile::new(cfg).unwrap());
 
             let writer = {
                 let f = file.clone();
@@ -902,7 +916,7 @@ mod tests {
         #[test]
         fn ok_concurrent_sync_and_write() {
             let (_dir, cfg) = tmp_path();
-            let file = sync::Arc::new(FrozenFile::new::<MID>(cfg).unwrap());
+            let file = sync::Arc::new(FrozenFile::new(cfg).unwrap());
 
             let writer = {
                 let f = file.clone();
@@ -938,7 +952,7 @@ mod tests {
         #[test]
         fn err_read_hcf_for_eof() {
             let (_dir, cfg) = tmp_path();
-            let file = FrozenFile::new::<MID>(cfg).unwrap();
+            let file = FrozenFile::new(cfg).unwrap();
 
             // index > curr_chunks
             let mut buf = [0; BUFFER_SIZE];

--- a/src/ffile/posix.rs
+++ b/src/ffile/posix.rs
@@ -1,10 +1,10 @@
-use super::{err, new_err, new_err_default, TFileId};
+use super::{TFileId, err};
 use crate::{error::FrozenResult, hints};
 use libc::{
-    access, c_int, c_uint, c_void, close, flock, fstat, ftruncate, iovec, off_t, open, pread, preadv, pwrite, pwritev,
-    size_t, stat, strerror, sysconf, unlink, EACCES, EAGAIN, EBADF, EBUSY, EFAULT, EINTR, EINVAL, EIO, EISDIR,
-    EMSGSIZE, ENOENT, ENOLCK, ENOSPC, ENOTDIR, EOPNOTSUPP, EPERM, EROFS, ESPIPE, EWOULDBLOCK, F_OK, LOCK_EX, LOCK_NB,
-    O_CLOEXEC, O_CREAT, O_DIRECTORY, O_RDONLY, O_RDWR, S_IRUSR, S_IWUSR, _SC_IOV_MAX,
+    _SC_IOV_MAX, EACCES, EAGAIN, EBADF, EBUSY, EFAULT, EINTR, EINVAL, EIO, EISDIR, EMSGSIZE, ENOENT, ENOLCK, ENOSPC,
+    ENOTDIR, EOPNOTSUPP, EPERM, EROFS, ESPIPE, EWOULDBLOCK, F_OK, LOCK_EX, LOCK_NB, O_CLOEXEC, O_CREAT, O_DIRECTORY,
+    O_RDONLY, O_RDWR, S_IRUSR, S_IWUSR, access, c_int, c_uint, c_void, close, flock, fstat, ftruncate, iovec, off_t,
+    open, pread, preadv, pwrite, pwritev, size_t, stat, strerror, sysconf, unlink,
 };
 use std::{ffi::CStr, mem, sync::atomic};
 
@@ -145,19 +145,19 @@ impl POSIXFile {
 
         match errno {
             // missing file or invalid path
-            ENOENT | ENOTDIR => new_err(err::INV, err_msg),
+            ENOENT | ENOTDIR => err::new_err(err::INV, err_msg),
 
             // lack of permission or read only fs
-            EACCES | EPERM | EROFS => new_err(err::PRM, err_msg),
+            EACCES | EPERM | EROFS => err::new_err(err::PRM, err_msg),
 
             // NOTE: In POSIX systems, kernel may report delayed io failures on `unlink`,
             // this are fatal errors, and can not be retried
             //
             // We protect this by enforcing hard durability right after write ops, so the
             // occurrence of this error is an implementation failure
-            EIO => new_err(err::HCF, err_msg),
+            EIO => err::new_err(err::HCF, err_msg),
 
-            _ => new_err(err::UNK, err_msg),
+            _ => err::new_err(err::UNK, err_msg),
         }
     }
 
@@ -172,10 +172,10 @@ impl POSIXFile {
 
             // bad or invalid fd
             if errno == EBADF || errno == EFAULT {
-                return new_err(err::HCF, err_msg);
+                return err::new_err(err::HCF, err_msg);
             }
 
-            return new_err(err::UNK, err_msg);
+            return err::new_err(err::UNK, err_msg);
         }
 
         Ok(st.st_size as usize)
@@ -294,7 +294,7 @@ impl POSIXFile {
             if res == 0 {
                 // NOTE: we treat this as `Hcf` error cause, this only occurs when we tried to read
                 // beyound current length of the file, which is result of invalid impl
-                return new_err_default(err::HCF);
+                return err::new_err_default(err::HCF);
             }
 
             if hints::unlikely(res < 0) {
@@ -306,12 +306,12 @@ impl POSIXFile {
                     EINTR | EAGAIN | EBUSY => continue,
 
                     // permission denied
-                    EACCES | EPERM => return new_err(err::RED, err_msg),
+                    EACCES | EPERM => return err::new_err(err::RED, err_msg),
 
                     // invalid fd, invalid fd type, bad pointer, etc.
-                    EINVAL | EBADF | EFAULT | ESPIPE => return new_err(err::HCF, err_msg),
+                    EINVAL | EBADF | EFAULT | ESPIPE => return err::new_err(err::HCF, err_msg),
 
-                    _ => return new_err(err::UNK, err_msg),
+                    _ => return err::new_err(err::UNK, err_msg),
                 }
             }
 
@@ -337,7 +337,7 @@ impl POSIXFile {
 
             // unexpected EOF
             if res == 0 {
-                return new_err_default(err::HCF);
+                return err::new_err_default(err::HCF);
             }
 
             if hints::unlikely(res < 0) {
@@ -349,12 +349,12 @@ impl POSIXFile {
                     EINTR | EAGAIN | EBUSY => continue,
 
                     // permission denied or read-only file
-                    EACCES | EPERM | EROFS => return new_err(err::WRT, err_msg),
+                    EACCES | EPERM | EROFS => return err::new_err(err::WRT, err_msg),
 
                     // invalid fd, invalid fd type, bad pointer, etc.
-                    EINVAL | EBADF | EFAULT | ESPIPE => return new_err(err::HCF, err_msg),
+                    EINVAL | EBADF | EFAULT | ESPIPE => return err::new_err(err::HCF, err_msg),
 
-                    _ => return new_err(err::UNK, err_msg),
+                    _ => return err::new_err(err::UNK, err_msg),
                 }
             }
 
@@ -391,7 +391,7 @@ impl POSIXFile {
             if res == 0 {
                 // NOTE: we treat this as `Hcf` error cause, this only occurs when we tried to read
                 // beyound current length of the file, which is result of invalid impl
-                return new_err_default(err::HCF);
+                return err::new_err_default(err::HCF);
             }
 
             if res < 0 {
@@ -402,12 +402,12 @@ impl POSIXFile {
                     EINTR | EAGAIN | EBUSY => continue,
 
                     // permission denied
-                    EACCES | EPERM => return new_err(err::RED, err_msg),
+                    EACCES | EPERM => return err::new_err(err::RED, err_msg),
 
                     // invalid fd, bad pointer, illegal seek, etc.
-                    EINVAL | EBADF | EFAULT | ESPIPE | EMSGSIZE => return new_err(err::HCF, err_msg),
+                    EINVAL | EBADF | EFAULT | ESPIPE | EMSGSIZE => return err::new_err(err::HCF, err_msg),
 
-                    _ => return new_err(err::UNK, err_msg),
+                    _ => return err::new_err(err::UNK, err_msg),
                 }
             }
 
@@ -466,7 +466,7 @@ impl POSIXFile {
 
             // unexpected EOF
             if res == 0 {
-                return new_err_default(err::HCF);
+                return err::new_err_default(err::HCF);
             }
 
             if res < 0 {
@@ -477,12 +477,12 @@ impl POSIXFile {
                     EINTR | EAGAIN | EBUSY => continue,
 
                     // permission denied
-                    EACCES | EPERM => return new_err(err::WRT, err_msg),
+                    EACCES | EPERM => return err::new_err(err::WRT, err_msg),
 
                     // invalid fd, bad pointer, illegal seek, etc.
-                    EINVAL | EBADF | EFAULT | ESPIPE | EMSGSIZE => return new_err(err::HCF, err_msg),
+                    EINVAL | EBADF | EFAULT | ESPIPE | EMSGSIZE => return err::new_err(err::HCF, err_msg),
 
-                    _ => return new_err(err::UNK, err_msg),
+                    _ => return err::new_err(err::UNK, err_msg),
                 }
             }
 
@@ -563,22 +563,22 @@ unsafe fn open_raw(path: &std::path::Path, flags: c_int) -> FrozenResult<TFileId
                         continue;
                     }
 
-                    return new_err(err::UNK, err_msg);
+                    return err::new_err(err::UNK, err_msg);
                 }
 
                 // no space available on disk
-                ENOSPC => return new_err(err::NSP, err_msg),
+                ENOSPC => return err::new_err(err::NSP, err_msg),
 
                 // path is a dir (hcf)
-                EISDIR => return new_err(err::HCF, err_msg),
+                EISDIR => return err::new_err(err::HCF, err_msg),
 
                 // invalid path (missing sub dir's)
-                ENOENT | ENOTDIR => return new_err(err::INV, err_msg),
+                ENOENT | ENOTDIR => return err::new_err(err::INV, err_msg),
 
                 // permission denied or read-only fs
-                EACCES | EPERM | EROFS => return new_err(err::PRM, err_msg),
+                EACCES | EPERM | EROFS => return err::new_err(err::PRM, err_msg),
 
-                _ => return new_err(err::UNK, err_msg),
+                _ => return err::new_err(err::UNK, err_msg),
             }
         }
 
@@ -605,10 +605,10 @@ unsafe fn close_raw(fd: TFileId) -> FrozenResult<()> {
     // We protect this by enforcing hard durability right after write ops, so the
     // occurrence of this error is an implementation failure
     if errno == EIO {
-        return new_err(err::HCF, err_msg);
+        return err::new_err(err::HCF, err_msg);
     }
 
-    new_err(err::UNK, err_msg)
+    err::new_err(err::UNK, err_msg)
 }
 
 #[cfg(target_os = "linux")]
@@ -624,13 +624,13 @@ unsafe fn fdatasync_raw(fd: TFileId) -> FrozenResult<()> {
 
         match errno {
             // invalid fd or lack of support for sync
-            EINVAL | EBADF => return new_err(err::HCF, err_msg),
+            EINVAL | EBADF => return err::new_err(err::HCF, err_msg),
 
             // read-only file (can also be caused by TOCTOU)
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
             // fatal error, i.e. no sync for writes in recent window/batch
-            EIO => return new_err(err::SYN, err_msg),
+            EIO => return err::new_err(err::SYN, err_msg),
 
             // IO interrupt or fatal error, i.e. no sync for writes in recent window/batch
             //
@@ -645,10 +645,10 @@ unsafe fn fdatasync_raw(fd: TFileId) -> FrozenResult<()> {
 
                 // NOTE: sync error indicates that retries exhausted and durability is broken
                 // in the current/last window/batch
-                return new_err(err::SYN, err_msg);
+                return err::new_err(err::SYN, err_msg);
             }
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -674,22 +674,22 @@ unsafe fn f_fullsync_raw(fd: TFileId) -> FrozenResult<()> {
 
                 // NOTE: sync error indicates that retries exhausted and durability is broken
                 // in the current/last window/batch
-                return new_err(err::SYN, err_msg);
+                return err::new_err(err::SYN, err_msg);
             }
 
             // lack of support for `F_FULLSYNC`
             libc::ENOTSUP | EOPNOTSUPP => break,
 
             // invalid fd or bad impl
-            EINVAL | EBADF => return new_err(err::HCF, err_msg),
+            EINVAL | EBADF => return err::new_err(err::HCF, err_msg),
 
             // read-only file (can also be caused by TOCTOU)
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
             // fatal error, i.e. no sync for writes in recent window/batch
-            EIO => return new_err(err::SYN, err_msg),
+            EIO => return err::new_err(err::SYN, err_msg),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 
@@ -722,19 +722,19 @@ unsafe fn fsync_raw(fd: TFileId) -> FrozenResult<()> {
 
                     // NOTE: sync error indicates that retries exhausted and durability is broken
                     // in the current/last window/batch
-                    return new_err(err::SYN, err_msg);
+                    return err::new_err(err::SYN, err_msg);
                 }
 
                 // invalid fd or lack of support for sync
-                EBADF | EINVAL => return new_err(err::HCF, err_msg),
+                EBADF | EINVAL => return err::new_err(err::HCF, err_msg),
 
                 // read-only file (can also be caused by TOCTOU)
-                EROFS => return new_err(err::PRM, err_msg),
+                EROFS => return err::new_err(err::PRM, err_msg),
 
                 // fatal error, i.e. no sync for writes in recent window/batch
-                EIO => return new_err(err::SYN, err_msg),
+                EIO => return err::new_err(err::SYN, err_msg),
 
-                _ => return new_err(err::UNK, err_msg),
+                _ => return err::new_err(err::UNK, err_msg),
             }
         }
 
@@ -766,17 +766,17 @@ unsafe fn sync_file_range_raw(fd: TFileId, offset: usize, len: usize) -> FrozenR
 
                 // NOTE: sync error indicates that retries exhausted and durability is broken
                 // in the current/last window/batch
-                return new_err(err::SYN, err_msg);
+                return err::new_err(err::SYN, err_msg);
             }
 
             // invalid fd or lack of support for sync
-            EBADF | EINVAL => return new_err(err::HCF, err_msg),
+            EBADF | EINVAL => return err::new_err(err::HCF, err_msg),
 
             // read-only file (can also be caused by TOCTOU)
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
             // fatal error, i.e. no sync for writes in recent window/batch
-            EIO => return new_err(err::SYN, err_msg),
+            EIO => return err::new_err(err::SYN, err_msg),
 
             // NOTE: on many fs mainly ones w/o local journaling, and older kernels does not support
             // `sync_file_range(SYNC_FILE_RANGE_WRITE)`, also as the use of this is only to hint the
@@ -784,7 +784,7 @@ unsafe fn sync_file_range_raw(fd: TFileId, offset: usize, len: usize) -> FrozenR
             // kind of errors
             EOPNOTSUPP | libc::ENOSYS => return Ok(()),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -826,24 +826,24 @@ unsafe fn fallocate_raw(fd: TFileId, curr_len: usize, len_to_add: usize) -> Froz
                     continue;
                 }
 
-                return new_err(err::GRW, err_msg);
+                return err::new_err(err::GRW, err_msg);
             }
 
             // invalid fd
-            EBADF | EINVAL => return new_err(err::HCF, err_msg),
+            EBADF | EINVAL => return err::new_err(err::HCF, err_msg),
 
             // read-only fs (can also be caused by TOCTOU)
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
             // no space available on disk to grow
-            ENOSPC => return new_err(err::NSP, err_msg),
+            ENOSPC => return err::new_err(err::NSP, err_msg),
 
             // NOTE: on many fs `fallocate()` may not be supported due to old kernel or fs
             // limitations, as use of this is only to hint the fs (for perf gains while
             // writes), we simply let go of this and do not elivate any kind of errors
             EOPNOTSUPP | libc::ENOSYS => return Ok(()),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -874,19 +874,19 @@ unsafe fn ftruncate_raw(fd: TFileId, curr_len: usize, len_to_add: usize) -> Froz
                     continue;
                 }
 
-                return new_err(err::GRW, err_msg);
+                return err::new_err(err::GRW, err_msg);
             }
 
             // invalid fd or lack of support for sync
-            EINVAL | EBADF => return new_err(err::HCF, err_msg),
+            EINVAL | EBADF => return err::new_err(err::HCF, err_msg),
 
             // read-only fs (can also be caused by TOCTOU)
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
             // no space available on disk to grow
-            ENOSPC => return new_err(err::NSP, err_msg),
+            ENOSPC => return err::new_err(err::NSP, err_msg),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -951,7 +951,7 @@ unsafe fn f_preallocate_raw(fd: TFileId, curr_len: usize, len_to_add: usize) -> 
                     continue;
                 }
 
-                return new_err(err::GRW, err_msg);
+                return err::new_err(err::GRW, err_msg);
             }
 
             // no space available on disk to grow
@@ -964,7 +964,7 @@ unsafe fn f_preallocate_raw(fd: TFileId, curr_len: usize, len_to_add: usize) -> 
                     continue;
                 }
 
-                return new_err(err::NSP, err_msg);
+                return err::new_err(err::NSP, err_msg);
             }
 
             // NOTE: on many fs `fcntl(F_PREALLOCATE)` may not be supported due to old kernel
@@ -976,12 +976,12 @@ unsafe fn f_preallocate_raw(fd: TFileId, curr_len: usize, len_to_add: usize) -> 
             EINVAL => return Ok(()), // same reason as above to not elivate the error
 
             // invalid fd
-            EBADF => return new_err(err::HCF, err_msg),
+            EBADF => return err::new_err(err::HCF, err_msg),
 
             // read-only fs
-            EROFS => return new_err(err::PRM, err_msg),
+            EROFS => return err::new_err(err::PRM, err_msg),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -999,7 +999,7 @@ unsafe fn flock_raw(fd: TFileId) -> FrozenResult<()> {
         match errno {
             // another process already holds the lock
             EWOULDBLOCK => {
-                return new_err(err::LCK, err_msg);
+                return err::new_err(err::LCK, err_msg);
             }
 
             // IO interrupt
@@ -1009,16 +1009,16 @@ unsafe fn flock_raw(fd: TFileId) -> FrozenResult<()> {
                     continue;
                 }
 
-                return new_err(err::LCK, err_msg);
+                return err::new_err(err::LCK, err_msg);
             }
 
             // invalid fd or lack of support
-            EBADF | EINVAL => return new_err(err::HCF, err_msg),
+            EBADF | EINVAL => return err::new_err(err::HCF, err_msg),
 
             // os or fs, out of locks, i.e. lock exhaustion, may happen only on nfs
-            ENOLCK => return new_err(err::LEX, err_msg),
+            ENOLCK => return err::new_err(err::LEX, err_msg),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }
@@ -1076,7 +1076,7 @@ const fn prep_flags() -> c_int {
 fn path_to_cstring(path: &std::path::Path) -> FrozenResult<std::ffi::CString> {
     match std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) {
         Ok(cs) => Ok(cs),
-        Err(e) => new_err(err::INV, e),
+        Err(e) => err::new_err(err::INV, e),
     }
 }
 
@@ -1116,7 +1116,7 @@ fn extract_parent_dir(path: &std::path::Path) -> std::path::PathBuf {
 unsafe fn read_max_iovec_config() -> FrozenResult<usize> {
     let res = sysconf(_SC_IOV_MAX);
     if res <= 0 {
-        return new_err_default(err::HCF);
+        return err::new_err_default(err::HCF);
     }
 
     Ok(res as usize)
@@ -1157,11 +1157,11 @@ unsafe fn f_advise_raw(fd: TFileId) -> FrozenResult<()> {
                     continue;
                 }
 
-                return new_err(err::UNK, err_msg);
+                return err::new_err(err::UNK, err_msg);
             }
 
             // invalid fd
-            EBADF | libc::ENOSYS | EINVAL => return new_err(err::HCF, err_msg),
+            EBADF | libc::ENOSYS | EINVAL => return err::new_err(err::HCF, err_msg),
 
             // as this is an best-effort call, we simply ignore if the call failed or advisory
             // hint is not supported
@@ -1260,7 +1260,7 @@ mod tests {
             unsafe {
                 let missing = path.join("missing/file");
                 let err = POSIXFile::new(&missing).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::INV.reason);
+                assert_eq!(err.reason, err::INV.reason);
             }
         }
     }
@@ -1290,7 +1290,7 @@ mod tests {
                 file.unlink(&path).unwrap();
 
                 let err = file.unlink(&path).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::INV.reason);
+                assert_eq!(err.reason, err::INV.reason);
             }
         }
     }
@@ -1320,7 +1320,7 @@ mod tests {
 
                 let file2 = POSIXFile::new(&path).unwrap();
                 let err = file2.flock().unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::LCK.reason);
+                assert_eq!(err.reason, err::LCK.reason);
 
                 file1.close().unwrap();
                 file2.close().unwrap();
@@ -1869,7 +1869,7 @@ mod tests {
                 file.close().unwrap();
 
                 let err = file.length().unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+                assert_eq!(err.reason, err::HCF.reason);
             }
         }
 
@@ -1884,7 +1884,7 @@ mod tests {
 
                 let mut buf = vec![0u8; 8];
                 let err = file.pread(buf.as_mut_ptr(), 0, buf.len()).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+                assert_eq!(err.reason, err::HCF.reason);
             }
         }
 
@@ -1899,7 +1899,7 @@ mod tests {
 
                 let mut data = b"dead".to_vec();
                 let err = file.pwrite(data.as_mut_ptr(), 0, data.len()).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+                assert_eq!(err.reason, err::HCF.reason);
             }
         }
 
@@ -1912,7 +1912,7 @@ mod tests {
                 file.close().unwrap();
 
                 let err = file.sync().unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+                assert_eq!(err.reason, err::HCF.reason);
             }
         }
 
@@ -1925,7 +1925,7 @@ mod tests {
                 file.close().unwrap();
 
                 let err = file.grow(0, 0x100).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::HCF.reason);
+                assert_eq!(err.reason, err::HCF.reason);
             }
         }
 
@@ -1940,7 +1940,7 @@ mod tests {
                 assert!(!path.exists());
 
                 let err = file.unlink(&path).unwrap_err();
-                assert_eq!((err.id & 0xffff) as u16, err::INV.reason);
+                assert_eq!(err.reason, err::INV.reason);
             }
         }
     }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -117,20 +117,17 @@ pub(in crate::fmmap) mod err {
     /// flush_tx error (unable to spawn)
     pub const FXE: ErrCode = ErrCode::new(0x10, "unable to spawn flush_tx");
 
-    /// lock poisoned
-    pub const LPN: ErrCode = ErrCode::new(0x12, "lock poisoned internally");
-
     /// type `T` implements drop
-    pub const DRP: ErrCode = ErrCode::new(0x14, "type T must not implement `Drop`");
+    pub const DRP: ErrCode = ErrCode::new(0x12, "type T must not implement `Drop`");
 
     /// type `T` is not 8 bytes aligned
-    pub const ALN: ErrCode = ErrCode::new(0x16, "type T must be 8-bytes aligned");
+    pub const ALN: ErrCode = ErrCode::new(0x14, "type T must be 8-bytes aligned");
 
     /// `size_of::<T>()` is not multiple of 8
-    pub const SZE: ErrCode = ErrCode::new(0x18, "`size_of::<T>()` must be multiple of 8 bytes");
+    pub const SZE: ErrCode = ErrCode::new(0x16, "`size_of::<T>()` must be multiple of 8 bytes");
 
     /// type `T` must not be zero sized
-    pub const ZRO: ErrCode = ErrCode::new(0x1A, "type T must not be zero sized");
+    pub const ZRO: ErrCode = ErrCode::new(0x18, "type T must not be zero sized");
 
     #[inline]
     pub(in crate::fmmap) fn new_err<R, E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenResult<R> {
@@ -302,8 +299,8 @@ where
         let (file, curr_length) = Self::open_file(path.as_ref().to_path_buf(), &cfg)?;
         let total_slots = curr_length / Self::SLOT_SIZE;
 
-        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
-        // first caller sets the value and all subsequent calls reuse it
+        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock`
+        // guarantees that the first caller sets the value and all subsequent calls reuse it
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
@@ -347,8 +344,8 @@ where
     /// ## Important
     ///
     /// The `cfg` must not change any of its properties for the entire life of [`FrozenFile`],
-    /// which is used under the hood, one must use config stores like [`Rta`](https://crates.io/crates/rta)
-    /// to store config.
+    /// which is used under the hood, one must use config stores like
+    /// [`Rta`](https://crates.io/crates/rta) to store config.
     ///
     /// ## Example
     ///
@@ -388,8 +385,8 @@ where
         let curr_length = file.length()?; // we must read the updated (grown) length
         let total_slots = curr_length / Self::SLOT_SIZE;
 
-        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
-        // first caller sets the value and all subsequent calls reuse it
+        // NOTE: The value is used for error logging and is initialized only once, as `OnceLock`
+        // guarantees that the first caller sets the value and all subsequent calls reuse it
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
@@ -485,11 +482,7 @@ where
             return Ok(());
         }
 
-        let mut guard = match self.core.durable_lock.lock() {
-            Ok(g) => g,
-            Err(e) => return err::new_err(err::LPN, e),
-        };
-
+        let mut guard = self.core.acquire_durable_lock();
         loop {
             if let Some(sync_err) = self.core.get_sync_error() {
                 return Err(sync_err);
@@ -499,10 +492,8 @@ where
                 return Ok(());
             }
 
-            guard = match self.core.durable_cv.wait(guard) {
-                Ok(g) => g,
-                Err(e) => return err::new_err(err::LPN, e),
-            };
+            // NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+            guard = self.core.durable_cv.wait(guard).unwrap_or_else(|e| e.into_inner());
         }
     }
 
@@ -555,8 +546,8 @@ where
         let offset = Self::SLOT_SIZE * index;
         let _lock = self.core.locks.lock(index);
 
-        // NOTE: We do avoid acquiring io_lock for read ops to increase the throughput (under the assumption of
-        // OS guarantees visibility)
+        // NOTE: We do avoid acquiring io_lock for read ops to increase the throughput (under the
+        // assumption of OS guarantees visibility)
 
         let ptr = unsafe { self.core.map.as_ptr(offset) };
         Ok(f(ptr))
@@ -613,7 +604,7 @@ where
 
         let offset = Self::SLOT_SIZE * index;
 
-        let _guard = self.core.acquire_io_lock()?;
+        let _guard = self.core.acquire_io_lock();
         let _lock = self.core.locks.lock(index);
 
         let ptr = unsafe { self.core.map.as_mut_ptr(offset) };
@@ -678,10 +669,10 @@ where
         let offset = Self::SLOT_SIZE * index;
 
         // block flush_tx scheduling
-        let _flush_guard = self.core.lock.lock().map_err(|e| err::new_err_raw(err::LPN, e))?;
+        let _flush_guard = self.core.acquire_lock();
 
         // we use exlusive lock as we perform blocking hard sync
-        let _guard = self.core.acquire_exclusive_io_lock()?;
+        let _guard = self.core.acquire_exclusive_io_lock();
 
         let _lock = self.core.locks.lock(index);
         let ptr = unsafe { self.core.map.as_mut_ptr(offset) };
@@ -690,15 +681,16 @@ where
         // blocking hard sync
         self.core.sync()?;
 
-        // NOTE: we hard sync we flushed an entier batch, so we can skip the sync via flush_tx as the
-        // current batch is durable
+        // NOTE: we hard sync we flushed an entier batch, so we can skip the sync via flush_tx as
+        // the current batch is durable
 
         self.core.mark_epoch_durable();
         let prev = self.core.dirty.swap(false, atomic::Ordering::AcqRel);
 
-        // NOTE: we must also notify cv's waiting for durability (we skip if there was no batch to sync)
+        // NOTE: we must also notify cv's waiting for durability (we skip if there was no batch to
+        // sync)
         if prev {
-            let _g = self.core.durable_lock.lock().map_err(|e| err::new_err_raw(err::LPN, e))?;
+            let _g = self.core.acquire_durable_lock();
             self.core.durable_cv.notify_all();
         }
 
@@ -832,8 +824,8 @@ where
     ///
     /// ## Working
     ///
-    /// When `delete` is called, all read, write, and (background) sync ops are paused (indefinitely),
-    /// whule deletion is done with following steps:
+    /// When `delete` is called, all read, write, and (background) sync ops are paused
+    /// (indefinitely), whule deletion is done with following steps:
     ///
     /// - acquire an exclusive `io_lock` (all other ops are paused indefinitely)
     /// - if any batch is pending for sync,
@@ -875,7 +867,7 @@ where
         }
 
         // pause all new write ops
-        let _lock = self.core.acquire_exclusive_io_lock()?;
+        let _lock = self.core.acquire_exclusive_io_lock();
 
         self.munmap()?;
         self.core.file.delete()
@@ -1096,7 +1088,7 @@ impl<'a, T> FMTransaction<'a, T> {
             return Err(err);
         }
 
-        let _guard = self.core.acquire_io_lock()?;
+        let _guard = self.core.acquire_io_lock();
 
         // NOTE: we must acquire all locks beforehand, to make sure all the write go through
         let mut guards = Vec::with_capacity(self.ops_vec.len());
@@ -1204,14 +1196,40 @@ impl Core {
         }
     }
 
+    /// ## Why we ignore [`std::sync::PoisonError`]?
+    ///
+    /// The mutex used for lock, is solely used as a parking primitive for [`Condvar`] and does not
+    /// protect any mutable state. All the pool invariants and accounting are maintained via atomics
+    /// and are completely seperated from the mutex.
+    ///
+    /// A poisoned mutex only indicates that another tx panicked while holding the lock, and indicates
+    /// an inconsistent state of the protected value. Since no state can be left partially modified
+    /// under this lock, there is no possible consistency risk to recover from and propagating the
+    /// poison error would only introduce unnecessary failures into the allocation path.
+    ///
+    /// Therefore, as best effort, we consume the [`std::sync::PoisonError`] and continue operating
+    /// with the recovered guard.
     #[inline]
-    fn acquire_io_lock(&self) -> FrozenResult<sync::RwLockReadGuard<'_, ()>> {
-        self.io_lock.read().map_err(|e| err::new_err_raw(err::LPN, e))
+    fn acquire_durable_lock(&self) -> sync::MutexGuard<'_, ()> {
+        self.durable_lock.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
     #[inline]
-    fn acquire_exclusive_io_lock(&self) -> FrozenResult<sync::RwLockWriteGuard<'_, ()>> {
-        self.io_lock.write().map_err(|e| err::new_err_raw(err::LPN, e))
+    fn acquire_lock(&self) -> sync::MutexGuard<'_, ()> {
+        self.lock.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+    #[inline]
+    fn acquire_io_lock(&self) -> sync::RwLockReadGuard<'_, ()> {
+        self.io_lock.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+    #[inline]
+    fn acquire_exclusive_io_lock(&self) -> sync::RwLockWriteGuard<'_, ()> {
+        self.io_lock.write().unwrap_or_else(|e| e.into_inner())
     }
 
     #[inline]
@@ -1272,14 +1290,7 @@ impl Core {
             // INFO: we must acquire an exclusive IO lock for sync, hence no write, read or
             // grow could kick in while sync is in progress
 
-            let io_lock = match core.acquire_exclusive_io_lock() {
-                Ok(lock) => lock,
-                Err(e) => {
-                    core.set_sync_error(e);
-                    core.cv.notify_all();
-                    return;
-                }
-            };
+            let io_lock = core.acquire_exclusive_io_lock();
 
             // INFO: we must drop the guard before syscall, as its a blocking operation and holding
             // the mutex while the syscall takes place is not a good idea, while we drop the mutex
@@ -1303,13 +1314,7 @@ impl Core {
                 Ok(_) => {
                     core.durable_epoch.store(target_epoch, atomic::Ordering::Release);
 
-                    let _g = match core.durable_lock.lock() {
-                        Ok(g) => g,
-                        Err(e) => {
-                            core.set_sync_error(err::new_err_raw(err::LPN, e));
-                            return;
-                        }
-                    };
+                    let _g = core.acquire_durable_lock();
 
                     core.clear_sync_error();
                     core.durable_cv.notify_all();
@@ -1321,14 +1326,7 @@ impl Core {
             }
 
             drop(io_lock);
-            guard = match core.lock.lock() {
-                Ok(g) => g,
-                Err(e) => {
-                    core.set_sync_error(err::new_err_raw(err::LPN, e));
-                    core.durable_cv.notify_all();
-                    return;
-                }
-            };
+            guard = core.acquire_lock();
         }
     }
 }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -58,7 +58,7 @@
 mod posix;
 
 use crate::{
-    error::{ErrCode, FrozenError, FrozenResult},
+    error::{FrozenError, FrozenResult},
     ffile::{FrozenFile, FrozenFileCfg},
     hints,
 };
@@ -68,86 +68,86 @@ use std::{
     thread, time,
 };
 
-/// Domain Id for [`FrozenMMap`] is **18**
-const ERRDOMAIN: u8 = 0x12;
-
 /// type for `epoch` used by write ops
 pub type TEpoch = u64;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 type TMap = posix::POSIXMMap;
 
-/// module id used for [`FrozenMMap`]
-static MID: sync::OnceLock<u8> = sync::OnceLock::new();
-
-#[cfg(not(test))]
-#[inline(always)]
-fn mid() -> &'static u8 {
-    MID.get().unwrap()
-}
-
-#[cfg(test)]
-#[inline(always)]
-fn mid() -> &'static u8 {
-    MID.get_or_init(|| 0)
-}
-
 /// Error codes for [`FrozenMMap`]
 pub(in crate::fmmap) mod err {
-    use super::ErrCode;
+    use crate::error::{ErrCode, FrozenError, FrozenResult};
 
-    /// (512) internal fuck up (hault and catch fire)
-    pub const HCF: ErrCode = ErrCode::new(0x200, "hault and catch fire");
+    /// Domain Id for [`FrozenMMap`] is **18**
+    const ERRDOMAIN: u8 = 0x12;
 
-    /// (513) unknown error (fallback)
-    pub const UNK: ErrCode = ErrCode::new(0x201, "unknown error");
+    /// module id used for [`FrozenMMap`]
+    pub static MID: std::sync::OnceLock<u8> = std::sync::OnceLock::new();
 
-    /// (514) no more memory available
-    pub const NMM: ErrCode = ErrCode::new(0x202, "not enough memory available on the device");
+    #[cfg(not(test))]
+    #[inline(always)]
+    pub fn mid() -> &'static u8 {
+        MID.get().unwrap()
+    }
 
-    /// (515) syncing error
-    pub const SYN: ErrCode = ErrCode::new(0x203, "failed to sync/flush data to storage device");
+    #[cfg(test)]
+    #[inline(always)]
+    pub fn mid() -> &'static u8 {
+        MID.get_or_init(|| 0)
+    }
 
-    /// (516) no write/read perm
-    pub const PRM: ErrCode = ErrCode::new(0x204, "missing permissions for IO");
+    /// internal fuck up (hault and catch fire)
+    pub const HCF: ErrCode = ErrCode::new(0x02, "hault and catch fire");
 
-    /// (517) flush_tx error (panic inside)
-    pub const TXE: ErrCode = ErrCode::new(0x205, "flush_tx paniced inside");
+    /// unknown error (fallback)
+    pub const UNK: ErrCode = ErrCode::new(0x04, "unknown error");
 
-    /// (518) flush_tx error (unable to spawn)
-    pub const FXE: ErrCode = ErrCode::new(0x206, "unable to spawn flush_tx");
+    /// no more memory available
+    pub const NMM: ErrCode = ErrCode::new(0x06, "not enough memory available on the device");
 
-    /// (519) lock poisoned
-    pub const LPN: ErrCode = ErrCode::new(0x207, "lock poisoned internally");
+    /// syncing error
+    pub const SYN: ErrCode = ErrCode::new(0x08, "failed to sync/flush data to storage device");
 
-    /// (520) type `T` implements drop
-    pub const DRP: ErrCode = ErrCode::new(0x208, "type T must not implement `Drop`");
+    /// no write/read perm
+    pub const PRM: ErrCode = ErrCode::new(0x0A, "missing permissions for IO");
 
-    /// (521) type `T` is not 8 bytes aligned
-    pub const ALN: ErrCode = ErrCode::new(0x209, "type T must be 8-bytes aligned");
+    /// flush_tx error (panic inside)
+    pub const TXE: ErrCode = ErrCode::new(0x0C, "flush_tx paniced inside");
 
-    /// (522) `size_of::<T>()` is not multiple of 8
-    pub const SZE: ErrCode = ErrCode::new(0x20A, "`size_of::<T>()` must be multiple of 8 bytes");
+    /// flush_tx error (unable to spawn)
+    pub const FXE: ErrCode = ErrCode::new(0x10, "unable to spawn flush_tx");
 
-    /// (523) type `T` must not be zero sized
-    pub const ZRO: ErrCode = ErrCode::new(0x20B, "type T must not be zero sized");
-}
+    /// lock poisoned
+    pub const LPN: ErrCode = ErrCode::new(0x12, "lock poisoned internally");
 
-#[inline]
-pub(in crate::fmmap) fn new_err<R, E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenResult<R> {
-    let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, error);
-    Err(err)
-}
+    /// type `T` implements drop
+    pub const DRP: ErrCode = ErrCode::new(0x14, "type T must not implement `Drop`");
 
-#[inline]
-pub(in crate::fmmap) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
-    let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, "");
-    Err(err)
-}
+    /// type `T` is not 8 bytes aligned
+    pub const ALN: ErrCode = ErrCode::new(0x16, "type T must be 8-bytes aligned");
 
-#[inline]
-pub(in crate::fmmap) fn new_err_raw<E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenError {
-    FrozenError::new_raw(*mid(), ERRDOMAIN, code, error)
+    /// `size_of::<T>()` is not multiple of 8
+    pub const SZE: ErrCode = ErrCode::new(0x18, "`size_of::<T>()` must be multiple of 8 bytes");
+
+    /// type `T` must not be zero sized
+    pub const ZRO: ErrCode = ErrCode::new(0x1A, "type T must not be zero sized");
+
+    #[inline]
+    pub(in crate::fmmap) fn new_err<R, E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenResult<R> {
+        let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, error);
+        Err(err)
+    }
+
+    #[inline]
+    pub(in crate::fmmap) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
+        let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, "");
+        Err(err)
+    }
+
+    #[inline]
+    pub(in crate::fmmap) fn new_err_raw<E: std::fmt::Display>(code: ErrCode, error: E) -> FrozenError {
+        FrozenError::new_raw(*mid(), ERRDOMAIN, code, error)
+    }
 }
 
 /// Config for [`FrozenMMap`]
@@ -304,7 +304,7 @@ where
 
         // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
         // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| cfg.module_id);
+        let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
         let core = sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
@@ -390,7 +390,7 @@ where
 
         // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
         // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| cfg.module_id);
+        let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
         let core = sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
@@ -419,21 +419,21 @@ where
     #[inline]
     fn validate_t() -> FrozenResult<()> {
         if std::mem::needs_drop::<T>() {
-            return new_err_default(err::DRP);
+            return err::new_err_default(err::DRP);
         }
 
         let align = std::mem::align_of::<T>();
         if align != 8 {
-            return new_err_default(err::ALN);
+            return err::new_err_default(err::ALN);
         }
 
         let size = std::mem::size_of::<T>();
         if size == 0 {
-            return new_err_default(err::ZRO);
+            return err::new_err_default(err::ZRO);
         }
 
         if size % 8 != 0 {
-            return new_err_default(err::SZE);
+            return err::new_err_default(err::SZE);
         }
 
         Ok(())
@@ -487,7 +487,7 @@ where
 
         let mut guard = match self.core.durable_lock.lock() {
             Ok(g) => g,
-            Err(e) => return new_err(err::LPN, e),
+            Err(e) => return err::new_err(err::LPN, e),
         };
 
         loop {
@@ -501,7 +501,7 @@ where
 
             guard = match self.core.durable_cv.wait(guard) {
                 Ok(g) => g,
-                Err(e) => return new_err(err::LPN, e),
+                Err(e) => return err::new_err(err::LPN, e),
             };
         }
     }
@@ -678,7 +678,7 @@ where
         let offset = Self::SLOT_SIZE * index;
 
         // block flush_tx scheduling
-        let _flush_guard = self.core.lock.lock().map_err(|e| new_err_raw(err::LPN, e))?;
+        let _flush_guard = self.core.lock.lock().map_err(|e| err::new_err_raw(err::LPN, e))?;
 
         // we use exlusive lock as we perform blocking hard sync
         let _guard = self.core.acquire_exclusive_io_lock()?;
@@ -698,7 +698,7 @@ where
 
         // NOTE: we must also notify cv's waiting for durability (we skip if there was no batch to sync)
         if prev {
-            let _g = self.core.durable_lock.lock().map_err(|e| new_err_raw(err::LPN, e))?;
+            let _g = self.core.durable_lock.lock().map_err(|e| err::new_err_raw(err::LPN, e))?;
             self.core.durable_cv.notify_all();
         }
 
@@ -1041,7 +1041,7 @@ impl<'a, T> FMTransaction<'a, T> {
         // If any of these is violated, there is a certain risk of deadlock in multi tx env's
         if let Some((last_idx, _)) = self.ops_vec.last() {
             if index <= *last_idx {
-                return new_err(
+                return err::new_err(
                     err::HCF,
                     "tx writes must be strictly ordered, with no more then single ops on given index",
                 );
@@ -1206,12 +1206,12 @@ impl Core {
 
     #[inline]
     fn acquire_io_lock(&self) -> FrozenResult<sync::RwLockReadGuard<'_, ()>> {
-        self.io_lock.read().map_err(|e| new_err_raw(err::LPN, e))
+        self.io_lock.read().map_err(|e| err::new_err_raw(err::LPN, e))
     }
 
     #[inline]
     fn acquire_exclusive_io_lock(&self) -> FrozenResult<sync::RwLockWriteGuard<'_, ()>> {
-        self.io_lock.write().map_err(|e| new_err_raw(err::LPN, e))
+        self.io_lock.write().map_err(|e| err::new_err_raw(err::LPN, e))
     }
 
     #[inline]
@@ -1228,7 +1228,7 @@ impl Core {
     fn spawn_tx(core: sync::Arc<Self>) -> FrozenResult<thread::JoinHandle<()>> {
         match thread::Builder::new().name("fm-flush-tx".into()).spawn(move || Self::flush_tx(core)) {
             Ok(tx) => Ok(tx),
-            Err(error) => new_err(err::FXE, error),
+            Err(error) => err::new_err(err::FXE, error),
         }
     }
 
@@ -1237,7 +1237,7 @@ impl Core {
         let mut guard = match core.lock.lock() {
             Ok(g) => g,
             Err(error) => {
-                core.set_sync_error(new_err_raw(err::FXE, error));
+                core.set_sync_error(err::new_err_raw(err::FXE, error));
                 core.cv.notify_all();
                 return;
             }
@@ -1248,7 +1248,7 @@ impl Core {
             guard = match core.cv.wait_timeout(guard, core.flush_duration) {
                 Ok((g, _)) => g,
                 Err(e) => {
-                    core.set_sync_error(new_err_raw(err::TXE, e));
+                    core.set_sync_error(err::new_err_raw(err::TXE, e));
                     core.cv.notify_all();
                     return;
                 }
@@ -1306,7 +1306,7 @@ impl Core {
                     let _g = match core.durable_lock.lock() {
                         Ok(g) => g,
                         Err(e) => {
-                            core.set_sync_error(new_err_raw(err::LPN, e));
+                            core.set_sync_error(err::new_err_raw(err::LPN, e));
                             return;
                         }
                     };
@@ -1324,7 +1324,7 @@ impl Core {
             guard = match core.lock.lock() {
                 Ok(g) => g,
                 Err(e) => {
-                    core.set_sync_error(new_err_raw(err::LPN, e));
+                    core.set_sync_error(err::new_err_raw(err::LPN, e));
                     core.durable_cv.notify_all();
                     return;
                 }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -57,7 +57,7 @@ mod posix;
 
 use crate::{
     error::{ErrCode, FrozenError, FrozenResult},
-    ffile::{FFCfg, FrozenFile},
+    ffile::{FrozenFile, FrozenFileCfg},
     hints,
 };
 use std::{
@@ -383,7 +383,7 @@ where
 
     /// Create/open a new [`FrozenFile`] instance
     fn open_file(path: std::path::PathBuf, cfg: &FMCfg) -> FrozenResult<(FrozenFile, usize)> {
-        let ff_cfg = FFCfg { path, chunk_size: Self::SLOT_SIZE, initial_chunk_amount: cfg.initial_count };
+        let ff_cfg = FrozenFileCfg { path, chunk_size: Self::SLOT_SIZE, initial_chunk_amount: cfg.initial_count };
 
         let file = FrozenFile::new::<MODULE_ID>(ff_cfg)?;
         let curr_length = file.length()?;

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -22,14 +22,14 @@
 //! ## Example
 //!
 //! ```
-//! use frozen_core::fmmap::{FrozenMMap, FMCfg};
+//! use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
 //!
 //! const MODULE_ID: u8 = 0;
 //!
 //! let dir = tempfile::tempdir().unwrap();
 //! let path = dir.path().join("tmp_frozen_mmap");
 //!
-//! let cfg = FMCfg {
+//! let cfg = FrozenMMapCfg {
 //!     initial_count: 0x0A,
 //!     flush_duration: std::time::Duration::from_micros(0x96),
 //! };
@@ -150,7 +150,7 @@ pub(in crate::fmmap) fn new_err_raw<E: std::fmt::Display>(code: ErrCode, error: 
 
 /// Config for [`FrozenMMap`]
 #[derive(Debug, Clone)]
-pub struct FMCfg {
+pub struct FrozenMMapCfg {
     /// Number of slots to pre-allocate when [`FrozenMMap`] is initialized
     ///
     /// Each slot has size of [`FrozenMMap::<T>::SLOT_SIZE`], where initial file length will
@@ -186,14 +186,14 @@ pub struct FMCfg {
 /// ## Example
 ///
 /// ```
-/// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+/// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
 ///
 /// const MODULE_ID: u8 = 0;
 ///
 /// let dir = tempfile::tempdir().unwrap();
 /// let path = dir.path().join("tmp_frozen_mmap");
 ///
-/// let cfg = FMCfg {
+/// let cfg = FrozenMMapCfg {
 ///     initial_count: 0x0A,
 ///     flush_duration: std::time::Duration::from_micros(0x96),
 /// };
@@ -235,7 +235,7 @@ where
     /// Memory space required for each slot of [`T`] in [`FrozenMMap`]
     pub const SLOT_SIZE: usize = std::mem::size_of::<T>();
 
-    /// Create a new [`FrozenMMap`] instance w/ given [`FMCfg`]
+    /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`]
     ///
     /// ## Multiple Instances
     ///
@@ -247,9 +247,9 @@ where
     /// [`FrozenMMap`] does not support in-place growth of a live mapping, to increase capacity, drop the current instance
     /// and reopen w/ [`FrozenMMap::open_grown`] which provides memory mapping over grown capacity
     ///
-    /// ## [`FMCfg`]
+    /// ## [`FrozenMMapCfg`]
     ///
-    /// All configs for [`FrozenMMap`] are stored in [`FMCfg`]
+    /// All configs for [`FrozenMMap`] are stored in [`FrozenMMapCfg`]
     ///
     /// ## Working
     ///
@@ -264,14 +264,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -285,7 +285,7 @@ where
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
     /// assert_eq!(val, 0xDEADC0DE);
     /// ```
-    pub fn new<P: AsRef<std::path::Path>>(path: P, cfg: FMCfg) -> FrozenResult<Self> {
+    pub fn new<P: AsRef<std::path::Path>>(path: P, cfg: FrozenMMapCfg) -> FrozenResult<Self> {
         Self::validate_t()?;
         let (file, curr_length) = Self::open_file(path.as_ref().to_path_buf(), &cfg)?;
         let total_slots = curr_length / Self::SLOT_SIZE;
@@ -303,7 +303,7 @@ where
         Ok(Self { core, tx: Some(tx), _t: core::marker::PhantomData })
     }
 
-    /// Create a new [`FrozenMMap`] instance w/ given [`FMCfg`], while growing the underlying [`FrozenFile`]
+    /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`], while growing the underlying [`FrozenFile`]
     /// by `additional_slots` before creating memory mapping
     ///
     /// ## Multiple Instances
@@ -320,9 +320,9 @@ where
     /// So, instead of remmaping a live instance, the current API performs growth during open, making capacity expansion
     /// an explicit lifecycle operation, and not a side effect on a live instance
     ///
-    /// ## [`FMCfg`]
+    /// ## [`FrozenMMapCfg`]
     ///
-    /// All configs for [`FrozenMMap`] are stored in [`FMCfg`]
+    /// All configs for [`FrozenMMap`] are stored in [`FrozenMMapCfg`]
     ///
     /// ## Working
     ///
@@ -338,14 +338,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_frozen_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -359,7 +359,11 @@ where
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
     /// assert_eq!(val, 0xDEADC0DE);
     /// ```
-    pub fn new_grown<P: AsRef<std::path::Path>>(path: P, cfg: FMCfg, additional_slots: usize) -> FrozenResult<Self> {
+    pub fn new_grown<P: AsRef<std::path::Path>>(
+        path: P,
+        cfg: FrozenMMapCfg,
+        additional_slots: usize,
+    ) -> FrozenResult<Self> {
         Self::validate_t()?;
         let (file, _) = Self::open_file(path.as_ref().to_path_buf(), &cfg)?;
 
@@ -382,7 +386,7 @@ where
     }
 
     /// Create/open a new [`FrozenFile`] instance
-    fn open_file(path: std::path::PathBuf, cfg: &FMCfg) -> FrozenResult<(FrozenFile, usize)> {
+    fn open_file(path: std::path::PathBuf, cfg: &FrozenMMapCfg) -> FrozenResult<(FrozenFile, usize)> {
         let ff_cfg = FrozenFileCfg { path, buffer_size: Self::SLOT_SIZE, initial_available_buffers: cfg.initial_count };
 
         let file = FrozenFile::new::<MODULE_ID>(ff_cfg)?;
@@ -428,14 +432,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_wait_epoch");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x04,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
@@ -501,14 +505,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_read_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
@@ -553,14 +557,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_write_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -617,14 +621,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_write_sync");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -682,14 +686,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_grow_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -714,14 +718,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_mem_usage");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
@@ -758,14 +762,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
@@ -808,14 +812,14 @@ where
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_delete_mmap");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x04,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
@@ -905,14 +909,14 @@ where
 /// ## Example
 ///
 /// ```
-/// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+/// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
 ///
 /// const MID: u8 = 0;
 ///
 /// let dir = tempfile::tempdir().unwrap();
 /// let path = dir.path().join("tmp_tx");
 ///
-/// let cfg = FMCfg {
+/// let cfg = FrozenMMapCfg {
 ///     initial_count: 0x0A,
 ///     flush_duration: std::time::Duration::from_micros(50),
 /// };
@@ -957,14 +961,14 @@ impl<'a, T> FMTransaction<'a, T> {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
@@ -1021,14 +1025,14 @@ impl<'a, T> FMTransaction<'a, T> {
     /// ## Example
     ///
     /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FMCfg};
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
     /// const MID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
-    /// let cfg = FMCfg {
+    /// let cfg = FrozenMMapCfg {
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
@@ -1364,11 +1368,11 @@ mod tests {
     const MID: u8 = 0;
     const INIT_SLOTS: usize = 0x0A;
 
-    fn new_tmp() -> (tempfile::TempDir, std::path::PathBuf, FMCfg) {
+    fn new_tmp() -> (tempfile::TempDir, std::path::PathBuf, FrozenMMapCfg) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_map");
 
-        let cfg = FMCfg { initial_count: INIT_SLOTS, flush_duration: FLUSH_DURATION };
+        let cfg = FrozenMMapCfg { initial_count: INIT_SLOTS, flush_duration: FLUSH_DURATION };
 
         (dir, path, cfg)
     }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -383,7 +383,7 @@ where
 
     /// Create/open a new [`FrozenFile`] instance
     fn open_file(path: std::path::PathBuf, cfg: &FMCfg) -> FrozenResult<(FrozenFile, usize)> {
-        let ff_cfg = FrozenFileCfg { path, chunk_size: Self::SLOT_SIZE, initial_chunk_amount: cfg.initial_count };
+        let ff_cfg = FrozenFileCfg { path, buffer_size: Self::SLOT_SIZE, initial_available_buffers: cfg.initial_count };
 
         let file = FrozenFile::new::<MODULE_ID>(ff_cfg)?;
         let curr_length = file.length()?;

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! ## Constraints
 //!
-//! [`FrozenMMap`] treats the mapped file as raw storage for values of `T`. Because of that, `T` must be a POD type
-//! which is safe to persist and later reinterpret from bytes.
+//! [`FrozenMMap`] treats the mapped file as raw storage for values of `T`. Because of that,
+//! `T` must be a POD type which is safe to persist and later reinterpret from bytes.
 //!
 //! Required properties for `T`,
 //!
@@ -12,12 +12,13 @@
 //! - Must not implement [`Drop`]
 //! - `size_of::<T>()` should be multiple of `8`
 //!
-//! *NOTE:* `T` must not contain heap owning or process-local pointers like [`Vec`], [`String`], [`Box`], references
-//! and function pointers, or other fields whose bit-pattern is not stable across reopen.
+//! *NOTE:* `T` must not contain heap owning or process-local pointers like [`Vec`], [`String`],
+//! [`Box`], references and function pointers, or other fields whose bit-pattern is not stable
+//! across reopen.
 //!
-//! These constrains are enforced as [`FrozenMMap`] does not serialize or deserialize values. It directly reads and
-//! writes `T` inside a memory mapped file. That means `T` must have a stable layout and must remain valid when the file
-//! is reopened in a later process.
+//! These constrains are enforced as [`FrozenMMap`] does not serialize or deserialize values. It
+//! directly reads and writes `T` inside a memory mapped file. That means `T` must have a stable
+//! layout and must remain valid when the file is reopened in a later process.
 //!
 //! ## Example
 //!
@@ -30,11 +31,12 @@
 //! let path = dir.path().join("tmp_frozen_mmap");
 //!
 //! let cfg = FrozenMMapCfg {
+//!     module_id: MODULE_ID,
 //!     initial_count: 0x0A,
 //!     flush_duration: std::time::Duration::from_micros(0x96),
 //! };
 //!
-//! let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg.clone()).unwrap();
+//! let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 //! assert_eq!(mmap.total_slots(), 0x0A);
 //!
 //! let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
@@ -45,7 +47,7 @@
 //!
 //! drop(mmap);
 //!
-//! let reopened = FrozenMMap::<u64, MODULE_ID>::new_grown(&path, cfg, 0x05).unwrap();
+//! let reopened = FrozenMMap::<u64>::new_grown(&path, cfg, 0x05).unwrap();
 //! assert_eq!(reopened.total_slots(), 0x0A + 0x05);
 //!
 //! let val = unsafe { reopened.read(0, |v| *v) }.unwrap();
@@ -151,6 +153,9 @@ pub(in crate::fmmap) fn new_err_raw<E: std::fmt::Display>(code: ErrCode, error: 
 /// Config for [`FrozenMMap`]
 #[derive(Debug, Clone)]
 pub struct FrozenMMapCfg {
+    /// Identifier used for error propagation by [`frozen_core::error::FrozenError`]
+    pub module_id: u8,
+
     /// Number of slots to pre-allocate when [`FrozenMMap`] is initialized
     ///
     /// Each slot has size of [`FrozenMMap::<T>::SLOT_SIZE`], where initial file length will
@@ -166,8 +171,8 @@ pub struct FrozenMMapCfg {
 ///
 /// ## Constraints
 ///
-/// [`FrozenMMap`] treats the mapped file as raw storage for values of `T`. Because of that, `T` must be a POD type
-/// which is safe to persist and later reinterpret from bytes.
+/// [`FrozenMMap`] treats the mapped file as raw storage for values of `T`. Because of that, `T`
+/// must be a POD type which is safe to persist and later reinterpret from bytes.
 ///
 /// Required properties for `T`,
 ///
@@ -176,12 +181,13 @@ pub struct FrozenMMapCfg {
 /// - Must not implement [`Drop`]
 /// - `size_of::<T>()` should be multiple of `8`
 ///
-/// *NOTE:* `T` must not contain heap owning or process-local pointers like [`Vec`], [`String`], [`Box`], references
-/// and function pointers, or other fields whose bit-pattern is not stable across reopen.
+/// *NOTE:* `T` must not contain heap owning or process-local pointers like [`Vec`], [`String`],
+/// [`Box`], references and function pointers, or other fields whose bit-pattern is not stable
+/// across reopen.
 ///
-/// These constrains are enforced as [`FrozenMMap`] does not serialize or deserialize values. It directly reads and
-/// writes `T` inside a memory mapped file. That means `T` must have a stable layout and must remain valid when the file
-/// is reopened in a later process.
+/// These constrains are enforced as [`FrozenMMap`] does not serialize or deserialize values. It
+/// directly reads and writes `T` inside a memory mapped file. That means `T` must have a stable
+/// layout and must remain valid when the file is reopened in a later process.
 ///
 /// ## Example
 ///
@@ -194,11 +200,12 @@ pub struct FrozenMMapCfg {
 /// let path = dir.path().join("tmp_frozen_mmap");
 ///
 /// let cfg = FrozenMMapCfg {
+///     module_id: MODULE_ID,
 ///     initial_count: 0x0A,
 ///     flush_duration: std::time::Duration::from_micros(0x96),
 /// };
 ///
-/// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg.clone()).unwrap();
+/// let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 /// assert_eq!(mmap.total_slots(), 0x0A);
 ///
 /// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
@@ -209,14 +216,14 @@ pub struct FrozenMMapCfg {
 ///
 /// drop(mmap);
 ///
-/// let reopened = FrozenMMap::<u64, MODULE_ID>::new_grown(&path, cfg, 0x05).unwrap();
+/// let reopened = FrozenMMap::<u64>::new_grown(&path, cfg, 0x05).unwrap();
 /// assert_eq!(reopened.total_slots(), 0x0A + 0x05);
 ///
 /// let val = unsafe { reopened.read(0, |v| *v) }.unwrap();
 /// assert_eq!(val, 0xDEADC0DE);
 /// ```
 #[derive(Debug)]
-pub struct FrozenMMap<T, const MODULE_ID: u8>
+pub struct FrozenMMap<T>
 where
     T: Sized + Send + Sync,
 {
@@ -225,10 +232,10 @@ where
     _t: core::marker::PhantomData<T>,
 }
 
-unsafe impl<T, const MODULE_ID: u8> Send for FrozenMMap<T, MODULE_ID> where T: Sized + Send + Sync {}
-unsafe impl<T, const MODULE_ID: u8> Sync for FrozenMMap<T, MODULE_ID> where T: Sized + Send + Sync {}
+unsafe impl<T> Send for FrozenMMap<T> where T: Sized + Send + Sync {}
+unsafe impl<T> Sync for FrozenMMap<T> where T: Sized + Send + Sync {}
 
-impl<T, const MODULE_ID: u8> FrozenMMap<T, MODULE_ID>
+impl<T> FrozenMMap<T>
 where
     T: Sized + Send + Sync,
 {
@@ -239,13 +246,15 @@ where
     ///
     /// ## Multiple Instances
     ///
-    /// For each [`FrozenMMap`] instance, we acquire an exclusive lock from the kernal for the underlying [`FrozenFile`],
-    /// when trying to create multiple instances of [`FrozenMMap`], an error will be thrown    ///
+    /// For each [`FrozenMMap`] instance, we acquire an exclusive lock from the kernal for the
+    /// underlying [`FrozenFile`], when trying to create multiple instances of [`FrozenMMap`], an
+    /// error will be thrown.
     ///
     /// ## Capacity Growth
     ///
-    /// [`FrozenMMap`] does not support in-place growth of a live mapping, to increase capacity, drop the current instance
-    /// and reopen w/ [`FrozenMMap::open_grown`] which provides memory mapping over grown capacity
+    /// [`FrozenMMap`] does not support in-place growth of a live mapping, to increase capacity,
+    /// drop the current instance and reopen w/ [`FrozenMMap::open_grown`] which provides memory
+    /// mapping over grown capacity.
     ///
     /// ## [`FrozenMMapCfg`]
     ///
@@ -253,13 +262,15 @@ where
     ///
     /// ## Working
     ///
-    /// We first create a new [`FrozenFile`] if note already, then map the entire file using `mmap(2)`,
-    /// the entire file must read/write `T`, which also should stay constant for the entire lifetime of file
+    /// We first create a new [`FrozenFile`] if note already, then map the entire file using
+    /// `mmap(2)`, the entire file must read/write `T`, which also should stay constant for the
+    /// entire lifetime of file.
     ///
     /// ## Important
     ///
-    /// The `cfg` must not change any of its properties for the entire life of [`FrozenFile`], which is used under
-    /// the hood, one must use config stores like [`Rta`](https://crates.io/crates/rta) to store config
+    /// The `cfg` must not change any of its properties for the entire life of [`FrozenFile`],
+    /// which is used under the hood, one must use config stores like [`Rta`](https://crates.io/crates/rta)
+    /// to store config.
     ///
     /// ## Example
     ///
@@ -272,11 +283,12 @@ where
     /// let path = dir.path().join("tmp_frozen_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg.clone()).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x0A);
     ///
     /// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
@@ -292,7 +304,7 @@ where
 
         // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
         // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| MODULE_ID);
+        let _ = MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
         let core = sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
@@ -303,22 +315,24 @@ where
         Ok(Self { core, tx: Some(tx), _t: core::marker::PhantomData })
     }
 
-    /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`], while growing the underlying [`FrozenFile`]
-    /// by `additional_slots` before creating memory mapping
+    /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`], while growing the
+    /// underlying [`FrozenFile`] by `additional_slots` before creating memory mapping
     ///
     /// ## Multiple Instances
     ///
-    /// For each [`FrozenMMap`] instance, we acquire an exclusive lock from the kernal for the underlying [`FrozenFile`],
-    /// when trying to create multiple instances of [`FrozenMMap`], an error will be thrown
+    /// For each [`FrozenMMap`] instance, we acquire an exclusive lock from the kernal for the
+    /// underlying [`FrozenFile`], when trying to create multiple instances of [`FrozenMMap`], an
+    /// error will be thrown.
     ///
     /// ## Why not create a [`FrozenMMap::grow`] call?
     ///
-    /// Previously when [`FrozenMMap::grow`] was attempted, it was observed that, resizing an active memory mapping
-    /// in place is tricky in concurrent code, as some threads would still hold stale/unmapped pointers to mmap
-    /// due to preemption from the OS schedular
+    /// Previously when [`FrozenMMap::grow`] was attempted, it was observed that, resizing an active
+    /// memory mapping in place is tricky in concurrent code, as some threads would still hold
+    /// stale/unmapped pointers to mmap due to preemption from the OS schedular
     ///
-    /// So, instead of remmaping a live instance, the current API performs growth during open, making capacity expansion
-    /// an explicit lifecycle operation, and not a side effect on a live instance
+    /// So, instead of remmaping a live instance, the current API performs growth during open,
+    /// making capacity expansion an explicit lifecycle operation, and not a side effect on a live
+    /// instance.
     ///
     /// ## [`FrozenMMapCfg`]
     ///
@@ -326,14 +340,15 @@ where
     ///
     /// ## Working
     ///
-    /// We first create a new [`FrozenFile`] if note already, then we grow the file using [`FrozenFile::grow`]
-    /// then map the entire file using `mmap(2)`, the entire file must read/write `T`, which also should stay
-    /// constant for the entire lifetime of file
+    /// We first create a new [`FrozenFile`] if note already, then we grow the file using
+    /// [`FrozenFile::grow`] then map the entire file using `mmap(2)`, the entire file must
+    /// read/write `T`, which also should stay constant for the entire lifetime of file.
     ///
     /// ## Important
     ///
-    /// The `cfg` must not change any of its properties for the entire life of [`FrozenFile`], which is used under
-    /// the hood, one must use config stores like [`Rta`](https://crates.io/crates/rta) to store config
+    /// The `cfg` must not change any of its properties for the entire life of [`FrozenFile`],
+    /// which is used under the hood, one must use config stores like [`Rta`](https://crates.io/crates/rta)
+    /// to store config.
     ///
     /// ## Example
     ///
@@ -346,11 +361,12 @@ where
     /// let path = dir.path().join("tmp_frozen_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new_grown(&path, cfg.clone(), 0x0A).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x0A).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x0A * 2);
     ///
     /// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
@@ -374,7 +390,7 @@ where
 
         // NOTE: The value is used for error logging and is initialized only once, as `OnceLock` guarantees that the
         // first caller sets the value and all subsequent calls reuse it
-        let _ = MID.get_or_init(|| MODULE_ID);
+        let _ = MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
         let core = sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
@@ -387,9 +403,14 @@ where
 
     /// Create/open a new [`FrozenFile`] instance
     fn open_file(path: std::path::PathBuf, cfg: &FrozenMMapCfg) -> FrozenResult<(FrozenFile, usize)> {
-        let ff_cfg = FrozenFileCfg { path, buffer_size: Self::SLOT_SIZE, initial_available_buffers: cfg.initial_count };
+        let ff_cfg = FrozenFileCfg {
+            path,
+            module_id: cfg.module_id,
+            buffer_size: Self::SLOT_SIZE,
+            initial_available_buffers: cfg.initial_count,
+        };
 
-        let file = FrozenFile::new::<MODULE_ID>(ff_cfg)?;
+        let file = FrozenFile::new(ff_cfg)?;
         let curr_length = file.length()?;
 
         Ok((file, curr_length))
@@ -422,12 +443,13 @@ where
     ///
     /// ## Batching
     ///
-    /// With respect to `flush_duration`, all write ops are batched before sync, which is executed by flusher tx
-    /// working in background, while each write is assigned w/ current durable epoch, and all writes which
-    /// observe the exact same epoch, belong to the same durability window, and are all sync'ed together
+    /// With respect to `flush_duration`, all write ops are batched before sync, which is executed
+    /// by flusher tx working in background, while each write is assigned w/ current durable epoch,
+    /// and all writes which observe the exact same epoch, belong to the same durability window, and
+    /// are all sync'ed together
     ///
-    /// When a background sync succeeds, the internal durable epoch is incremented, indicating that all writes
-    /// that observed the previous epoch are now durable on disk
+    /// When a background sync succeeds, the internal durable epoch is incremented, indicating that
+    /// all writes that observed the previous epoch are now durable on disk
     ///
     /// ## Example
     ///
@@ -440,11 +462,12 @@ where
     /// let path = dir.path().join("tmp_wait_epoch");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x04,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let epoch = unsafe { mmap.write(0, |v| *v = 0x8A) }.unwrap();
     /// mmap.wait_for_durability(epoch).unwrap();
@@ -487,8 +510,9 @@ where
     ///
     /// ## Concurrency
     ///
-    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for at same index is atomic
-    /// and thread safe, while operations on different indices may proceed fully in parallel
+    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for
+    /// at same index is atomic and thread safe, while operations on different indices may proceed
+    /// fully in parallel
     ///
     /// ## Safety
     ///
@@ -513,11 +537,12 @@ where
     /// let path = dir.path().join("tmp_read_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let epoch = unsafe { mmap.write(0, |v| *v = 0x0A) }.unwrap();
     /// mmap.wait_for_durability(epoch).unwrap();
@@ -541,8 +566,9 @@ where
     ///
     /// ## Concurrency
     ///
-    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for at same index is atomic
-    /// and thread safe, while operations on different indices may proceed fully in parallel
+    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for
+    /// at same index is atomic and thread safe, while operations on different indices may proceed
+    /// fully in parallel
     ///
     /// ## Safety
     ///
@@ -565,11 +591,12 @@ where
     /// let path = dir.path().join("tmp_write_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let epoch = unsafe {mmap.write(1, |v| *v = 0x2B) }.unwrap();
     /// mmap.wait_for_durability(epoch).unwrap();
@@ -600,13 +627,14 @@ where
 
     /// Write/update a `T` at given `index` via callback (`f`) w/ instant durability
     ///
-    /// This function performs a blocking hard-sync, unlike [`FrozenMMap::write`], the update is immediately
-    /// persisted to the underlying storage device
+    /// This function performs a blocking hard-sync, unlike [`FrozenMMap::write`], the update is
+    /// immediately persisted to the underlying storage device
     ///
     /// ## Concurrency
     ///
-    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for at same index is atomic
-    /// and thread safe, while operations on different indices may proceed fully in parallel
+    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for
+    /// at same index is atomic and thread safe, while operations on different indices may proceed
+    /// fully in parallel.
     ///
     /// ## Safety
     ///
@@ -629,11 +657,12 @@ where
     /// let path = dir.path().join("tmp_write_sync");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     /// unsafe { mmap.write_sync(0, |v| *v = 0xC0DE) }.unwrap();
     ///
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
@@ -680,8 +709,9 @@ where
     ///
     /// ## Working
     ///
-    /// This call performs a syscall to fetch current length of [`FrozenFile`] from fs, as the current length of the
-    /// file is not cached anywhere in the pipeline to avoid TOCTAU race conditions
+    /// This call performs a syscall to fetch current length of [`FrozenFile`] from fs, as the
+    /// current length of the file is not cached anywhere in the pipeline to avoid TOCTAU race
+    /// conditions
     ///
     /// ## Example
     ///
@@ -694,16 +724,17 @@ where
     /// let path = dir.path().join("tmp_grow_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x02,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg.clone()).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x02);
     ///
     /// drop(mmap);
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new_grown(&path, cfg, 0x03).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new_grown(&path, cfg, 0x03).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x02 + 0x03);
     /// ```
     #[inline]
@@ -713,7 +744,8 @@ where
 
     /// Read the total memory footprint (in bytes) used by [`FrozenMMap`]
     ///
-    /// *NOTE:* This is an approzimation of memory used, actual RSS may differ depending on paging and OS
+    /// *NOTE:* This is an approzimation of memory used, actual RSS may differ depending on paging
+    /// and OS
     ///
     /// ## Example
     ///
@@ -726,11 +758,12 @@ where
     /// let path = dir.path().join("tmp_mem_usage");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(0x60),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let bytes = mmap.memory_usage();
     /// assert!(bytes >= mmap.total_slots() * std::mem::size_of::<u64>());
@@ -746,12 +779,13 @@ where
         mmap_bytes + lock_bytes
     }
 
-    /// Create a new [`FMTransaction`] context for grouping multi write ops into a single atomic operation
+    /// Create a new [`FMTransaction`] context for grouping multi write ops into a single atomic
+    /// operation
     ///
     /// ## Overview
     ///
-    /// The use of [`FMTransaction`] allows to group multiple write ops into a single atomic operation, hence
-    /// creating a transactional write operation, which gives following guarantees,
+    /// The use of [`FMTransaction`] allows to group multiple write ops into a single atomic
+    /// operation, hence creating a transactional write operation, which gives following guarantees:
     ///
     /// - All write ops succeed together
     /// - Single epoch to track durability of all writes ops
@@ -764,17 +798,18 @@ where
     /// ```
     /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
-    /// const MID: u8 = 0;
+    /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x0A,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let mut tx = mmap.new_tx();
     /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
@@ -820,11 +855,12 @@ where
     /// let path = dir.path().join("tmp_delete_mmap");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x04,
     ///     flush_duration: std::time::Duration::from_micros(0x96),
     /// };
     ///
-    /// let mut mmap = FrozenMMap::<u64, MODULE_ID>::new(&path, cfg).unwrap();
+    /// let mut mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     /// mmap.delete().unwrap();
     /// assert!(!path.exists());
     /// ```
@@ -852,7 +888,7 @@ where
     }
 }
 
-impl<T, const MODULE_ID: u8> Drop for FrozenMMap<T, MODULE_ID>
+impl<T> Drop for FrozenMMap<T>
 where
     T: Sized + Send + Sync,
 {
@@ -881,7 +917,7 @@ where
     }
 }
 
-impl<T, const MODULE_ID: u8> fmt::Display for FrozenMMap<T, MODULE_ID>
+impl<T> fmt::Display for FrozenMMap<T>
 where
     T: Sized + Send + Sync,
 {
@@ -911,17 +947,18 @@ where
 /// ```
 /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
 ///
-/// const MID: u8 = 0;
+/// const MODULE_ID: u8 = 0;
 ///
 /// let dir = tempfile::tempdir().unwrap();
 /// let path = dir.path().join("tmp_tx");
 ///
 /// let cfg = FrozenMMapCfg {
+///     module_id: MODULE_ID,
 ///     initial_count: 0x0A,
 ///     flush_duration: std::time::Duration::from_micros(50),
 /// };
 ///
-/// let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+/// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
 ///
 /// let mut tx = mmap.new_tx();
 /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
@@ -963,17 +1000,18 @@ impl<'a, T> FMTransaction<'a, T> {
     /// ```
     /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
-    /// const MID: u8 = 0;
+    /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let mut tx = mmap.new_tx();
     /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
@@ -1027,17 +1065,18 @@ impl<'a, T> FMTransaction<'a, T> {
     /// ```
     /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
     ///
-    /// const MID: u8 = 0;
+    /// const MODULE_ID: u8 = 0;
     ///
     /// let dir = tempfile::tempdir().unwrap();
     /// let path = dir.path().join("tmp_tx");
     ///
     /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
     ///     initial_count: 0x10,
     ///     flush_duration: std::time::Duration::from_micros(50),
     /// };
     ///
-    /// let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
     /// let mut tx = mmap.new_tx();
     /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
@@ -1215,8 +1254,8 @@ impl Core {
                 }
             };
 
-            // NOTE: we must read values of close brodcast before acquire exclusive lock,
-            // if done otherwise, we impose serious deadlock sort of situation for the the flusher tx
+            // NOTE: we must read values of close brodcast before acquire exclusive lock, if done
+            // otherwise, we impose serious deadlock sort of situation for the the flusher tx
 
             let dirty = core.dirty.swap(false, atomic::Ordering::AcqRel);
             let closing = core.closed.load(atomic::Ordering::Acquire);
@@ -1247,9 +1286,9 @@ impl Core {
             // and acqurie it again, in-between other process could acquire it and use it
             drop(guard);
 
-            // NOTE: We snapshot `current_epoch` before sync to establish a strict batch boundary, all writes
-            // up to `target_epoch` are guaranteed to be part of this flush window, while anything beyound belongs
-            // to the next batch
+            // NOTE: We snapshot `current_epoch` before sync to establish a strict batch boundary,
+            // all writes up to `target_epoch` are guaranteed to be part of this flush window,
+            // while anything beyound belongs to the next batch
             let target_epoch = core.current_epoch.load(atomic::Ordering::Acquire);
 
             // NOTE:
@@ -1365,14 +1404,14 @@ mod tests {
     // NOTE: we keep this small on purpose, so we won't have to wait at all in tests
     const FLUSH_DURATION: time::Duration = time::Duration::from_micros(10);
 
-    const MID: u8 = 0;
+    const MODULE_ID: u8 = 0;
     const INIT_SLOTS: usize = 0x0A;
 
     fn new_tmp() -> (tempfile::TempDir, std::path::PathBuf, FrozenMMapCfg) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_map");
 
-        let cfg = FrozenMMapCfg { initial_count: INIT_SLOTS, flush_duration: FLUSH_DURATION };
+        let cfg = FrozenMMapCfg { module_id: MODULE_ID, initial_count: INIT_SLOTS, flush_duration: FLUSH_DURATION };
 
         (dir, path, cfg)
     }
@@ -1383,13 +1422,13 @@ mod tests {
         #[test]
         fn ok_new() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             assert_eq!(mmap.core.flush_duration, FLUSH_DURATION);
             assert!(!mmap.core.dirty.load(atomic::Ordering::Acquire));
             assert!(!mmap.core.closed.load(atomic::Ordering::Acquire));
             assert_eq!(mmap.core.durable_epoch.load(atomic::Ordering::Acquire), 0);
-            assert_eq!(mmap.core.curr_length, INIT_SLOTS * FrozenMMap::<u64, MID>::SLOT_SIZE);
+            assert_eq!(mmap.core.curr_length, INIT_SLOTS * FrozenMMap::<u64>::SLOT_SIZE);
 
             // satisfies the bg thread was spawned correctly
             assert!(mmap.core.error.load(atomic::Ordering::Acquire).is_null());
@@ -1404,11 +1443,11 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
 
             // create new + close
-            let mmap1 = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mmap1 = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
             drop(mmap1);
 
             // open existing
-            let mmap2 = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap2 = FrozenMMap::<u64>::new(path, cfg).unwrap();
             drop(mmap2);
         }
 
@@ -1417,18 +1456,18 @@ mod tests {
             let (_dir, path, mut cfg) = new_tmp();
 
             // create new + close
-            let mmap1 = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mmap1 = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
             drop(mmap1);
 
             // update cfg + opne existing
             cfg.initial_count = INIT_SLOTS * 2;
-            assert!(FrozenMMap::<u64, MID>::new(path, cfg).is_err());
+            assert!(FrozenMMap::<u64>::new(path, cfg).is_err());
         }
 
         #[test]
         fn ok_delete() {
             let (_dir, path, cfg) = new_tmp();
-            let mut mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mut mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 
             mmap.delete().unwrap();
             assert!(!mmap.core.file.exists().unwrap());
@@ -1437,7 +1476,7 @@ mod tests {
         #[test]
         fn err_delete_after_delete() {
             let (_dir, path, cfg) = new_tmp();
-            let mut mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mut mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 
             mmap.delete().unwrap();
             assert!(!mmap.core.file.exists().unwrap());
@@ -1450,13 +1489,13 @@ mod tests {
             const VAL: u64 = 0x0A;
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 unsafe { mmap.write(0, |byte| *byte = VAL).unwrap() };
                 drop(mmap);
             }
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 let val = unsafe { mmap.read(0, |byte| *byte).unwrap() };
                 assert_eq!(val, VAL);
             }
@@ -1496,75 +1535,75 @@ mod tests {
 
         #[test]
         fn ok_validate_t() {
-            assert!(FrozenMMap::<OkT, MID>::validate_t().is_ok());
+            assert!(FrozenMMap::<OkT>::validate_t().is_ok());
         }
 
         #[test]
         fn err_validate_t_when_drop() {
-            assert!(FrozenMMap::<DropT, MID>::validate_t().is_err());
+            assert!(FrozenMMap::<DropT>::validate_t().is_err());
         }
 
         #[test]
         fn err_validate_t_when_not_8_byte_aligned() {
-            assert!(FrozenMMap::<BadAlignT, MID>::validate_t().is_err());
+            assert!(FrozenMMap::<BadAlignT>::validate_t().is_err());
         }
 
         #[test]
         fn err_validate_t_when_size_not_multiple_of_8() {
-            assert!(FrozenMMap::<BadSizeT, MID>::validate_t().is_err());
+            assert!(FrozenMMap::<BadSizeT>::validate_t().is_err());
         }
 
         #[test]
         fn err_validate_t_when_zero_sized() {
-            assert!(FrozenMMap::<ZstT, MID>::validate_t().is_err());
+            assert!(FrozenMMap::<ZstT>::validate_t().is_err());
         }
 
         #[test]
         fn err_new_when_t_implements_drop() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<DropT, MID>::new(path, cfg).is_err());
+            assert!(FrozenMMap::<DropT>::new(path, cfg).is_err());
         }
 
         #[test]
         fn err_new_when_t_is_not_8_byte_aligned() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<BadAlignT, MID>::new(path, cfg).is_err());
+            assert!(FrozenMMap::<BadAlignT>::new(path, cfg).is_err());
         }
 
         #[test]
         fn err_new_when_t_size_is_not_multiple_of_8() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<BadSizeT, MID>::new(path, cfg).is_err());
+            assert!(FrozenMMap::<BadSizeT>::new(path, cfg).is_err());
         }
 
         #[test]
         fn err_new_when_t_is_zero_sized() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<ZstT, MID>::new(path, cfg).is_err());
+            assert!(FrozenMMap::<ZstT>::new(path, cfg).is_err());
         }
 
         #[test]
         fn err_new_grown_when_t_implements_drop() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<DropT, MID>::new_grown(path, cfg, 1).is_err());
+            assert!(FrozenMMap::<DropT>::new_grown(path, cfg, 1).is_err());
         }
 
         #[test]
         fn err_new_grown_when_t_is_not_8_byte_aligned() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<BadAlignT, MID>::new_grown(path, cfg, 1).is_err());
+            assert!(FrozenMMap::<BadAlignT>::new_grown(path, cfg, 1).is_err());
         }
 
         #[test]
         fn err_new_grown_when_t_size_is_not_multiple_of_8() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<BadSizeT, MID>::new_grown(path, cfg, 1).is_err());
+            assert!(FrozenMMap::<BadSizeT>::new_grown(path, cfg, 1).is_err());
         }
 
         #[test]
         fn err_new_grown_when_t_is_zero_sized() {
             let (_dir, path, cfg) = new_tmp();
-            assert!(FrozenMMap::<ZstT, MID>::new_grown(path, cfg, 1).is_err());
+            assert!(FrozenMMap::<ZstT>::new_grown(path, cfg, 1).is_err());
         }
     }
 
@@ -1575,41 +1614,41 @@ mod tests {
         fn ok_new_grown_updates_length() {
             let (_dir, path, cfg) = new_tmp();
 
-            let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS);
             drop(mmap);
 
-            let mmap = FrozenMMap::<u64, MID>::new_grown(path, cfg, 0x0A).unwrap();
+            let mmap = FrozenMMap::<u64>::new_grown(path, cfg, 0x0A).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS + 0x0A);
-            assert_eq!(mmap.core.curr_length, (INIT_SLOTS + 0x0A) * FrozenMMap::<u64, MID>::SLOT_SIZE);
+            assert_eq!(mmap.core.curr_length, (INIT_SLOTS + 0x0A) * FrozenMMap::<u64>::SLOT_SIZE);
         }
 
         #[test]
         fn err_new_grown_with_preexisting_instance() {
             let (_dir, path, cfg) = new_tmp();
 
-            let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS);
 
-            assert!(FrozenMMap::<u64, MID>::new_grown(path, cfg, 0x0A).is_err());
+            assert!(FrozenMMap::<u64>::new_grown(path, cfg, 0x0A).is_err());
         }
 
         #[test]
         fn ok_new_grown_cycle() {
             let (_dir, path, cfg) = new_tmp();
 
-            let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+            let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
             drop(mmap);
 
-            let mmap = FrozenMMap::<u64, MID>::new_grown(&path, cfg.clone(), 0x100).unwrap();
+            let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x100).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS + 0x100);
             drop(mmap);
 
-            let mmap = FrozenMMap::<u64, MID>::new_grown(&path, cfg.clone(), 0x100).unwrap();
+            let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x100).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS + (2 * 0x100));
             drop(mmap);
 
-            let mmap = FrozenMMap::<u64, MID>::new_grown(path, cfg, 0x100).unwrap();
+            let mmap = FrozenMMap::<u64>::new_grown(path, cfg, 0x100).unwrap();
             assert_eq!(mmap.total_slots(), INIT_SLOTS + (3 * 0x100));
         }
 
@@ -1618,12 +1657,12 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 unsafe { mmap.write(0, |v| *v = 0xAA).unwrap() };
             }
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new_grown(&path, cfg.clone(), 0x10).unwrap();
+                let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x10).unwrap();
                 unsafe { mmap.write(0, |v| *v = 0xBB).unwrap() };
 
                 let val = unsafe { mmap.read(0, |v| *v).unwrap() };
@@ -1636,18 +1675,18 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 unsafe { mmap.write(0, |v| *v = 1).unwrap() };
             }
 
             for i in 0..2 {
-                let mmap = FrozenMMap::<u64, MID>::new_grown(&path, cfg.clone(), 0x10).unwrap();
+                let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x10).unwrap();
                 let idx = mmap.total_slots() - 1;
                 unsafe { mmap.write(idx, |v| *v = (i + 2) as u64).unwrap() };
                 drop(mmap);
             }
 
-            let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
 
             let base = unsafe { mmap.read(0, |v| *v).unwrap() };
             assert_eq!(base, 1);
@@ -1661,8 +1700,8 @@ mod tests {
         fn err_new_grown_while_previous_instance_is_alive() {
             let (_dir, path, cfg) = new_tmp();
 
-            let _mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
-            let reopened = FrozenMMap::<u64, MID>::new_grown(&path, cfg, 0x10);
+            let _mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
+            let reopened = FrozenMMap::<u64>::new_grown(&path, cfg, 0x10);
 
             assert!(reopened.is_err());
         }
@@ -1675,7 +1714,7 @@ mod tests {
         fn ok_write_wait_read_cycle() {
             const VAL: u64 = 0xDEADC0DE;
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             // write + sync
             let epoch = unsafe { mmap.write(0, |ptr| *ptr = VAL).unwrap() };
@@ -1690,7 +1729,7 @@ mod tests {
         fn ok_write_read_without_wait() {
             const VAL: u64 = 0xDEADC0DE;
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             unsafe { mmap.write(0, |ptr| *ptr = VAL).unwrap() };
             let val = unsafe { mmap.read(0, |ptr| *ptr).unwrap() };
@@ -1704,7 +1743,7 @@ mod tests {
         #[test]
         fn ok_write_sync_read() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             unsafe { mmap.write_sync(0, |v| *v = 0x4C).unwrap() };
 
@@ -1715,7 +1754,7 @@ mod tests {
         #[test]
         fn ok_write_sync_wait_returns_immediately() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let _ = unsafe { mmap.write_sync(0, |v| *v = 0x6A).unwrap() };
 
@@ -1727,7 +1766,7 @@ mod tests {
         fn ok_write_sync_followed_by_async_write() {
             let (_dir, path, cfg) = new_tmp();
 
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
             unsafe { mmap.write_sync(0, |v| *v = 0x0A).unwrap() };
 
             let epoch = unsafe { mmap.write(0, |v| *v = 0x14).unwrap() };
@@ -1740,7 +1779,7 @@ mod tests {
         #[test]
         fn ok_write_sync_makes_prev_batch_durable() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let async_epoch = unsafe { mmap.write(0, |v| *v = 1).unwrap() };
             unsafe { mmap.write_sync(1, |v| *v = 2).unwrap() };
@@ -1759,12 +1798,12 @@ mod tests {
             const VAL: u64 = 0x1000;
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 unsafe { mmap.write_sync(0, |v| *v = VAL).unwrap() };
             }
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
                 let val = unsafe { mmap.read(0, |v| *v).unwrap() };
                 assert_eq!(val, VAL);
             }
@@ -1777,7 +1816,7 @@ mod tests {
         #[test]
         fn ok_tx_basic_multi_write() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let mut tx = mmap.new_tx();
             unsafe {
@@ -1799,7 +1838,7 @@ mod tests {
         #[test]
         fn ok_tx_single_epoch() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let mut tx = mmap.new_tx();
             unsafe {
@@ -1818,7 +1857,7 @@ mod tests {
         #[test]
         fn err_tx_out_of_order() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let mut tx = mmap.new_tx();
             unsafe {
@@ -1831,7 +1870,7 @@ mod tests {
         #[test]
         fn err_tx_duplicate_index() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let mut tx = mmap.new_tx();
             unsafe {
@@ -1844,7 +1883,7 @@ mod tests {
         #[test]
         fn ok_tx_concurrent_non_overlapping() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = sync::Arc::new(FrozenMMap::<u64, MID>::new(path, cfg).unwrap());
+            let mmap = sync::Arc::new(FrozenMMap::<u64>::new(path, cfg).unwrap());
 
             let mut handles = Vec::new();
             for i in 0..2 {
@@ -1877,7 +1916,7 @@ mod tests {
         #[test]
         fn ok_tx_overwrite_last_wins() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let mut tx = mmap.new_tx();
             unsafe {
@@ -1903,7 +1942,7 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 
                 let mut tx = mmap.new_tx();
                 unsafe {
@@ -1916,7 +1955,7 @@ mod tests {
             }
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new(&path, cfg).unwrap();
+                let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
 
                 let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
                 let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
@@ -1932,7 +1971,7 @@ mod tests {
         #[test]
         fn ok_wait_then_drop() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let epoch = unsafe { mmap.write(0, |v| *v = 7).unwrap() };
             mmap.wait_for_durability(epoch).unwrap();
@@ -1943,7 +1982,7 @@ mod tests {
         #[test]
         fn ok_epoch_monotonicity() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64, MID>::new(path, cfg).unwrap();
+            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             let e1 = unsafe { mmap.write(0, |v| *v = 1).unwrap() };
             mmap.wait_for_durability(e1).unwrap();
@@ -1956,7 +1995,7 @@ mod tests {
         #[test]
         fn ok_wait_for_durability_with_multi_writers() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = sync::Arc::new(FrozenMMap::<u64, MID>::new(path, cfg).unwrap());
+            let mmap = sync::Arc::new(FrozenMMap::<u64>::new(path, cfg).unwrap());
 
             let mut handles = Vec::new();
             for _ in 0..2 {
@@ -1982,7 +2021,7 @@ mod tests {
         #[test]
         fn ok_parallel_reads_with_diff_index() {
             let (_dir, path, cfg) = new_tmp();
-            let mmap = sync::Arc::new(FrozenMMap::<u64, MID>::new(path, cfg).unwrap());
+            let mmap = sync::Arc::new(FrozenMMap::<u64>::new(path, cfg).unwrap());
 
             unsafe { mmap.write(0, |v| *v = 0x10).unwrap() };
             unsafe { mmap.write(1, |v| *v = 0x20).unwrap() };
@@ -2006,7 +2045,7 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
 
             {
-                let mmap = sync::Arc::new(FrozenMMap::<u64, MID>::new(&path, cfg.clone()).unwrap());
+                let mmap = sync::Arc::new(FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap());
 
                 let mut handles = Vec::new();
                 for i in 0..2u64 {
@@ -2029,7 +2068,7 @@ mod tests {
             }
 
             {
-                let mmap = FrozenMMap::<u64, MID>::new_grown(&path, cfg.clone(), 0x10).unwrap();
+                let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x10).unwrap();
                 assert_eq!(mmap.total_slots(), INIT_SLOTS + 0x10);
 
                 for i in 0..2u64 {

--- a/src/fmmap/posix.rs
+++ b/src/fmmap/posix.rs
@@ -207,17 +207,20 @@ mod tests {
     use crate::ffile::{FrozenFile, FrozenFileCfg};
 
     const MOD_ID: u8 = 0;
-    const CHUNK: usize = 0x10;
-    const INIT_CHUNKS: usize = 0x0A;
-    const LENGTH: usize = CHUNK * INIT_CHUNKS;
+    const BUFFER_SIZE: usize = 0x10;
+    const INIT_BUFFERS: usize = 0x0A;
+    const LENGTH: usize = BUFFER_SIZE * INIT_BUFFERS;
 
     fn new_tmp() -> (tempfile::TempDir, FrozenFile) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_map");
 
-        let file =
-            FrozenFile::new::<MOD_ID>(FrozenFileCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS })
-                .expect("new FF");
+        let file = FrozenFile::new::<MOD_ID>(FrozenFileCfg {
+            path,
+            buffer_size: BUFFER_SIZE,
+            initial_available_buffers: INIT_BUFFERS,
+        })
+        .expect("new FF");
 
         (dir, file)
     }
@@ -455,7 +458,7 @@ mod tests {
             // open + map + read
             unsafe {
                 let path = dir.path().join("tmp_map");
-                let cfg = FrozenFileCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS };
+                let cfg = FrozenFileCfg { path, buffer_size: BUFFER_SIZE, initial_available_buffers: INIT_BUFFERS };
 
                 let file = FrozenFile::new::<MOD_ID>(cfg).expect("new FF");
                 let mmap = POSIXMMap::new(file.fd(), LENGTH).unwrap();

--- a/src/fmmap/posix.rs
+++ b/src/fmmap/posix.rs
@@ -215,8 +215,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_map");
 
-        let file = FrozenFile::new::<MOD_ID>(FrozenFileCfg {
+        let file = FrozenFile::new(FrozenFileCfg {
             path,
+            module_id: MOD_ID,
             buffer_size: BUFFER_SIZE,
             initial_available_buffers: INIT_BUFFERS,
         })
@@ -458,9 +459,14 @@ mod tests {
             // open + map + read
             unsafe {
                 let path = dir.path().join("tmp_map");
-                let cfg = FrozenFileCfg { path, buffer_size: BUFFER_SIZE, initial_available_buffers: INIT_BUFFERS };
+                let cfg = FrozenFileCfg {
+                    path,
+                    module_id: MOD_ID,
+                    buffer_size: BUFFER_SIZE,
+                    initial_available_buffers: INIT_BUFFERS,
+                };
 
-                let file = FrozenFile::new::<MOD_ID>(cfg).expect("new FF");
+                let file = FrozenFile::new(cfg).expect("new FF");
                 let mmap = POSIXMMap::new(file.fd(), LENGTH).unwrap();
 
                 let ptr = mmap.as_ptr::<u64>(0);

--- a/src/fmmap/posix.rs
+++ b/src/fmmap/posix.rs
@@ -2,8 +2,8 @@ use super::{err, new_err};
 use crate::{error::FrozenResult, hints};
 use core::{ffi::CStr, ptr};
 use libc::{
-    c_void, mmap, msync, munmap, off_t, size_t, strerror, EACCES, EAGAIN, EBADF, EBUSY, EINTR, EINVAL, EIO, ENODEV,
-    ENOMEM, EOVERFLOW, EPERM, ETXTBSY, MAP_FAILED, MAP_SHARED, MS_SYNC, PROT_READ, PROT_WRITE,
+    EACCES, EAGAIN, EBADF, EBUSY, EINTR, EINVAL, EIO, ENODEV, ENOMEM, EOVERFLOW, EPERM, ETXTBSY, MAP_FAILED,
+    MAP_SHARED, MS_SYNC, PROT_READ, PROT_WRITE, c_void, mmap, msync, munmap, off_t, size_t, strerror,
 };
 
 /// Base pointer for `mmap(2)` mapped memory
@@ -204,7 +204,7 @@ unsafe fn err_msg(errno: i32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ffile::{FFCfg, FrozenFile};
+    use crate::ffile::{FrozenFile, FrozenFileCfg};
 
     const MOD_ID: u8 = 0;
     const CHUNK: usize = 0x10;
@@ -215,8 +215,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("tmp_map");
 
-        let file = FrozenFile::new::<MOD_ID>(FFCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS })
-            .expect("new FF");
+        let file =
+            FrozenFile::new::<MOD_ID>(FrozenFileCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS })
+                .expect("new FF");
 
         (dir, file)
     }
@@ -454,7 +455,7 @@ mod tests {
             // open + map + read
             unsafe {
                 let path = dir.path().join("tmp_map");
-                let cfg = FFCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS };
+                let cfg = FrozenFileCfg { path, chunk_size: CHUNK, initial_chunk_amount: INIT_CHUNKS };
 
                 let file = FrozenFile::new::<MOD_ID>(cfg).expect("new FF");
                 let mmap = POSIXMMap::new(file.fd(), LENGTH).unwrap();

--- a/src/fmmap/posix.rs
+++ b/src/fmmap/posix.rs
@@ -1,4 +1,4 @@
-use super::{err, new_err};
+use super::err;
 use crate::{error::FrozenResult, hints};
 use core::{ffi::CStr, ptr};
 use libc::{
@@ -96,19 +96,19 @@ unsafe fn mmap_raw(fd: i32, length: size_t) -> FrozenResult<TPtr> {
                         continue;
                     }
 
-                    return new_err(err::UNK, err_msg);
+                    return err::new_err(err::UNK, err_msg);
                 }
 
                 // invalid fd, invalid fd type, invalid length, etc.
-                EINVAL | EBADF | EOVERFLOW => return new_err(err::HCF, err_msg),
+                EINVAL | EBADF | EOVERFLOW => return err::new_err(err::HCF, err_msg),
 
                 // no more memory available
-                ENOMEM => return new_err(err::NMM, err_msg),
+                ENOMEM => return err::new_err(err::NMM, err_msg),
 
                 // permission denied or read-only file
-                EACCES | EPERM | ENODEV | ETXTBSY => return new_err(err::PRM, err_msg),
+                EACCES | EPERM | ENODEV | ETXTBSY => return err::new_err(err::PRM, err_msg),
 
-                _ => return new_err(err::UNK, err_msg),
+                _ => return err::new_err(err::UNK, err_msg),
             };
         }
 
@@ -127,9 +127,9 @@ unsafe fn munmap_raw(ptr: TPtr, length: size_t) -> FrozenResult<()> {
 
     match errno {
         // invalid/unaligned ptr or address range is not mapped
-        EINVAL | ENOMEM => new_err(err::HCF, err_msg),
+        EINVAL | ENOMEM => err::new_err(err::HCF, err_msg),
 
-        _ => new_err(err::UNK, err_msg),
+        _ => err::new_err(err::UNK, err_msg),
     }
 }
 
@@ -161,19 +161,19 @@ unsafe fn msync_raw(ptr: TPtr, length: size_t) -> FrozenResult<()> {
 
                 // NOTE: sync error indicates that retries exhausted and durability is broken
                 // in the current/last window/batch
-                return new_err(err::SYN, err_msg);
+                return err::new_err(err::SYN, err_msg);
             }
 
             // fatal error, i.e. no sync for writes in recent window/batch
-            EIO => return new_err(err::SYN, err_msg),
+            EIO => return err::new_err(err::SYN, err_msg),
 
             // invalid fd or lack of support for sync
-            EINVAL => return new_err(err::HCF, err_msg),
+            EINVAL => return err::new_err(err::HCF, err_msg),
 
             // no-more memory available
-            ENOMEM => return new_err(err::NMM, err_msg),
+            ENOMEM => return err::new_err(err::NMM, err_msg),
 
-            _ => return new_err(err::UNK, err_msg),
+            _ => return err::new_err(err::UNK, err_msg),
         }
     }
 }

--- a/src/wpipe.rs
+++ b/src/wpipe.rs
@@ -43,11 +43,12 @@
 //!
 //! let file_cfg = ffile::FrozenFileCfg {
 //!     path,
+//!     module_id: MODULE_ID,
 //!     initial_available_buffers: 0x400,
 //!     buffer_size: BUFFER_SIZE as usize,
 //! };
 //! let file = sync::Arc::new(
-//!     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+//!     ffile::FrozenFile::new(file_cfg)
 //!         .expect("file creation should succeed"),
 //! );
 //!
@@ -157,11 +158,12 @@ pub struct WritePipeCfg {
 ///
 /// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
+///     module_id: MODULE_ID,
 ///     initial_available_buffers: 0x400,
 ///     buffer_size: BUFFER_SIZE as usize,
 /// };
 /// let file = sync::Arc::new(
-///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+///     ffile::FrozenFile::new(file_cfg)
 ///         .expect("file creation should succeed"),
 /// );
 ///
@@ -235,11 +237,12 @@ impl WritePipe {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
+    ///     module_id: MODULE_ID,
     ///     initial_available_buffers: 0x400,
     ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
-    ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+    ///     ffile::FrozenFile::new(file_cfg)
     ///         .expect("file creation should succeed"),
     /// );
     ///
@@ -306,11 +309,12 @@ impl WritePipe {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
+    ///     module_id: MODULE_ID,
     ///     initial_available_buffers: 0x400,
     ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
-    ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+    ///     ffile::FrozenFile::new(file_cfg)
     ///         .expect("file creation should succeed"),
     /// );
     ///
@@ -493,11 +497,12 @@ pub struct WriteRequest {
 ///
 /// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
+///     module_id: MODULE_ID,
 ///     initial_available_buffers: 0x400,
 ///     buffer_size: BUFFER_SIZE as usize,
 /// };
 /// let file = sync::Arc::new(
-///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+///     ffile::FrozenFile::new(file_cfg)
 ///         .expect("file creation should succeed"),
 /// );
 ///
@@ -552,11 +557,12 @@ impl WriteTicket {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
+    ///     module_id: MODULE_ID,
     ///     initial_available_buffers: 0x400,
     ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
-    ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
+    ///     ffile::FrozenFile::new(file_cfg)
     ///         .expect("file creation should succeed"),
     /// );
     ///
@@ -882,11 +888,12 @@ mod tests {
 
     fn new_objects<P: AsRef<std::path::Path>>(path: P) -> (sync::Arc<ffile::FrozenFile>, bufpool::BufPool, WritePipe) {
         let file_cfg = ffile::FrozenFileCfg {
+            module_id: MODULE_ID,
             path: path.as_ref().to_path_buf(),
             buffer_size: BUFFER_SIZE as usize,
             initial_available_buffers: INITIAL_BUFFER_AMOUT,
         };
-        let file = sync::Arc::new(ffile::FrozenFile::new::<MODULE_ID>(file_cfg).unwrap());
+        let file = sync::Arc::new(ffile::FrozenFile::new(file_cfg).unwrap());
 
         let pool_cfg =
             bufpool::BufPoolCfg { buffer_size: BUFFER_SIZE, max_memory: INITIAL_BUFFER_AMOUT * BUFFER_SIZE as usize };
@@ -935,10 +942,11 @@ mod tests {
 
             let file_cfg = ffile::FrozenFileCfg {
                 path,
+                module_id: MODULE_ID,
                 buffer_size: BUFFER_SIZE as usize,
                 initial_available_buffers: INITIAL_BUFFER_AMOUT,
             };
-            let file = sync::Arc::new(ffile::FrozenFile::new::<MODULE_ID>(file_cfg).unwrap());
+            let file = sync::Arc::new(ffile::FrozenFile::new(file_cfg).unwrap());
 
             let pipe_cfg = WritePipeCfg { module_id: MODULE_ID, flush_duration: FLUSH_DURATION };
             assert!(WritePipe::new(pipe_cfg, file).is_ok());

--- a/src/wpipe.rs
+++ b/src/wpipe.rs
@@ -43,8 +43,8 @@
 //!
 //! let file_cfg = ffile::FrozenFileCfg {
 //!     path,
-//!     initial_chunk_amount: 0x400,
-//!     chunk_size: BUFFER_SIZE as usize,
+//!     initial_available_buffers: 0x400,
+//!     buffer_size: BUFFER_SIZE as usize,
 //! };
 //! let file = sync::Arc::new(
 //!     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -157,8 +157,8 @@ pub struct WritePipeCfg {
 ///
 /// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
-///     initial_chunk_amount: 0x400,
-///     chunk_size: BUFFER_SIZE as usize,
+///     initial_available_buffers: 0x400,
+///     buffer_size: BUFFER_SIZE as usize,
 /// };
 /// let file = sync::Arc::new(
 ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -235,8 +235,8 @@ impl WritePipe {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
-    ///     initial_chunk_amount: 0x400,
-    ///     chunk_size: BUFFER_SIZE as usize,
+    ///     initial_available_buffers: 0x400,
+    ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
     ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -306,8 +306,8 @@ impl WritePipe {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
-    ///     initial_chunk_amount: 0x400,
-    ///     chunk_size: BUFFER_SIZE as usize,
+    ///     initial_available_buffers: 0x400,
+    ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
     ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -493,8 +493,8 @@ pub struct WriteRequest {
 ///
 /// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
-///     initial_chunk_amount: 0x400,
-///     chunk_size: BUFFER_SIZE as usize,
+///     initial_available_buffers: 0x400,
+///     buffer_size: BUFFER_SIZE as usize,
 /// };
 /// let file = sync::Arc::new(
 ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -552,8 +552,8 @@ impl WriteTicket {
     ///
     /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
-    ///     initial_chunk_amount: 0x400,
-    ///     chunk_size: BUFFER_SIZE as usize,
+    ///     initial_available_buffers: 0x400,
+    ///     buffer_size: BUFFER_SIZE as usize,
     /// };
     /// let file = sync::Arc::new(
     ///     ffile::FrozenFile::new::<MODULE_ID>(file_cfg)
@@ -883,8 +883,8 @@ mod tests {
     fn new_objects<P: AsRef<std::path::Path>>(path: P) -> (sync::Arc<ffile::FrozenFile>, bufpool::BufPool, WritePipe) {
         let file_cfg = ffile::FrozenFileCfg {
             path: path.as_ref().to_path_buf(),
-            chunk_size: BUFFER_SIZE as usize,
-            initial_chunk_amount: INITIAL_BUFFER_AMOUT,
+            buffer_size: BUFFER_SIZE as usize,
+            initial_available_buffers: INITIAL_BUFFER_AMOUT,
         };
         let file = sync::Arc::new(ffile::FrozenFile::new::<MODULE_ID>(file_cfg).unwrap());
 
@@ -935,8 +935,8 @@ mod tests {
 
             let file_cfg = ffile::FrozenFileCfg {
                 path,
-                chunk_size: BUFFER_SIZE as usize,
-                initial_chunk_amount: INITIAL_BUFFER_AMOUT,
+                buffer_size: BUFFER_SIZE as usize,
+                initial_available_buffers: INITIAL_BUFFER_AMOUT,
             };
             let file = sync::Arc::new(ffile::FrozenFile::new::<MODULE_ID>(file_cfg).unwrap());
 

--- a/src/wpipe.rs
+++ b/src/wpipe.rs
@@ -638,17 +638,17 @@ impl std::future::Future for WriteTicket {
 
 /// ## Why we ignore [`std::sync::PoisonError`]?
 ///
-/// The mutex used for lock, is solely used as a parking primitive for [`Condvar`] and does not protect any mutable
-/// state. All the pool invariants and accounting are maintained via atomics and are completely seperated from
-/// the mutex.
+/// The mutex used for lock, is solely used as a parking primitive for [`Condvar`] and does not
+/// protect any mutable state. All the pool invariants and accounting are maintained via atomics
+/// and are completely seperated from the mutex.
 ///
-/// A poisoned mutex only indicates that another tx panicked while holding the lock, and indicates an inconsistent
-/// state of the protected value. Since no state can be left partially modified under this lock, there is no
-/// possible consistency risk to recover from and propagating the poison error would only introduce unnecessary
-/// failures into the allocation path.
+/// A poisoned mutex only indicates that another tx panicked while holding the lock, and indicates
+/// an inconsistent state of the protected value. Since no state can be left partially modified
+/// under this lock, there is no possible consistency risk to recover from and propagating the
+/// poison error would only introduce unnecessary failures into the allocation path.
 ///
-/// Therefore, as best effort, we consume the [`std::sync::PoisonError`] and continue operating with the recovered
-/// guard.
+/// Therefore, as best effort, we consume the [`std::sync::PoisonError`] and continue operating
+/// with the recovered guard.
 fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
     let mut guard = core.flush_guard.lock().unwrap_or_else(|e| e.into_inner());
     loop {

--- a/src/wpipe.rs
+++ b/src/wpipe.rs
@@ -41,7 +41,7 @@
 //! let dir = tempfile::tempdir().expect("tempdir creation should succeed");
 //! let path = dir.path().join("wpipe_example");
 //!
-//! let file_cfg = ffile::FFCfg {
+//! let file_cfg = ffile::FrozenFileCfg {
 //!     path,
 //!     initial_chunk_amount: 0x400,
 //!     chunk_size: BUFFER_SIZE as usize,
@@ -155,7 +155,7 @@ pub struct WritePipeCfg {
 /// let dir = tempfile::tempdir().expect("tempdir creation should succeed");
 /// let path = dir.path().join("wpipe_example");
 ///
-/// let file_cfg = ffile::FFCfg {
+/// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
 ///     initial_chunk_amount: 0x400,
 ///     chunk_size: BUFFER_SIZE as usize,
@@ -233,7 +233,7 @@ impl WritePipe {
     /// let dir = tempfile::tempdir().expect("tempdir creation should succeed");
     /// let path = dir.path().join("wpipe_example");
     ///
-    /// let file_cfg = ffile::FFCfg {
+    /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
     ///     initial_chunk_amount: 0x400,
     ///     chunk_size: BUFFER_SIZE as usize,
@@ -304,7 +304,7 @@ impl WritePipe {
     /// let dir = tempfile::tempdir().expect("tempdir creation should succeed");
     /// let path = dir.path().join("wpipe_example");
     ///
-    /// let file_cfg = ffile::FFCfg {
+    /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
     ///     initial_chunk_amount: 0x400,
     ///     chunk_size: BUFFER_SIZE as usize,
@@ -491,7 +491,7 @@ pub struct WriteRequest {
 /// let dir = tempfile::tempdir().expect("tempdir creation should succeed");
 /// let path = dir.path().join("wpipe_example");
 ///
-/// let file_cfg = ffile::FFCfg {
+/// let file_cfg = ffile::FrozenFileCfg {
 ///     path,
 ///     initial_chunk_amount: 0x400,
 ///     chunk_size: BUFFER_SIZE as usize,
@@ -550,7 +550,7 @@ impl WriteTicket {
     /// let dir = tempfile::tempdir().expect("tempdir creation should succeed");
     /// let path = dir.path().join("wpipe_example");
     ///
-    /// let file_cfg = ffile::FFCfg {
+    /// let file_cfg = ffile::FrozenFileCfg {
     ///     path,
     ///     initial_chunk_amount: 0x400,
     ///     chunk_size: BUFFER_SIZE as usize,
@@ -881,7 +881,7 @@ mod tests {
     const FLUSH_DURATION: time::Duration = time::Duration::from_millis(1);
 
     fn new_objects<P: AsRef<std::path::Path>>(path: P) -> (sync::Arc<ffile::FrozenFile>, bufpool::BufPool, WritePipe) {
-        let file_cfg = ffile::FFCfg {
+        let file_cfg = ffile::FrozenFileCfg {
             path: path.as_ref().to_path_buf(),
             chunk_size: BUFFER_SIZE as usize,
             initial_chunk_amount: INITIAL_BUFFER_AMOUT,
@@ -933,8 +933,11 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("write_single");
 
-            let file_cfg =
-                ffile::FFCfg { path, chunk_size: BUFFER_SIZE as usize, initial_chunk_amount: INITIAL_BUFFER_AMOUT };
+            let file_cfg = ffile::FrozenFileCfg {
+                path,
+                chunk_size: BUFFER_SIZE as usize,
+                initial_chunk_amount: INITIAL_BUFFER_AMOUT,
+            };
             let file = sync::Arc::new(ffile::FrozenFile::new::<MODULE_ID>(file_cfg).unwrap());
 
             let pipe_cfg = WritePipeCfg { module_id: MODULE_ID, flush_duration: FLUSH_DURATION };


### PR DESCRIPTION
- Improved `FrozenError` in `error` module
- Fixed syntax error for bench table in module docs for `bufpool`
- `ffile`
  - Renamed `FFCfg` -> `FrozenFileCfg`
  - Added `module_id` in `FrozenFileCfg`
  - Migrated to use latest `FrozenError`
- `fmmap`
  - Renamed `FMCfg` -> `FrozenMMapCfg`
  - Added `module_id` in `FrozenMMapCfg`
  - Migrated to use latest `FrozenError`
  - Impl of error recovery for lock poisoning on Mutex & RwLock