### PR TITLE
Impr: Migrate `fmmap::FrozenMMap` to use `ack` module for future impl and providing durability guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `0.0.25`
+
+- Migrated `fmmap::FrozenMMap` to use `ack` for future impl and durability guarantee (#57)
+
 ## `0.0.24`
 
 - Impl of `ack` module (#58)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frozen-core"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "criterion",
  "event-listener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2024"
-version = "0.0.24"
+version = "0.0.25"
 name = "frozen-core"
 readme = "README.md"
 rust-version = "1.86.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ ffile = [
     "hints",
 ]
 fmmap = [
+    "ack",
     "libc",
     "error",
     "hints",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add following to your `Cargo.toml`,
 
 ```toml
 [dependencies]
-frozen-core = { version = "0.0.24", default-features = true }
+frozen-core = { version = "0.0.25", default-features = true }
 ```
 
 > [!NOTE]

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -1886,4 +1886,65 @@ mod tests {
             }
         }
     }
+
+    mod ack_ticket {
+        use super::*;
+
+        #[test]
+        fn ok_parallel_waiters_same_epoch_window() {
+            let (_dir, path, cfg) = new_tmp();
+            let mmap = sync::Arc::new(FrozenMMap::<u64>::new(path, cfg).unwrap());
+
+            let barrier = sync::Arc::new(sync::Barrier::new(0x10));
+
+            let mut handles = Vec::new();
+            for i in 0..0x10usize {
+                let mmap = mmap.clone();
+                let barrier = barrier.clone();
+
+                handles.push(thread::spawn(move || {
+                    barrier.wait();
+
+                    let ticket = unsafe { mmap.write(i % INIT_SLOTS, |v| *v = i as u64).unwrap() };
+
+                    let epoch = ticket.epoch();
+                    let durable = futures::executor::block_on(ticket).unwrap();
+
+                    assert!(durable >= epoch);
+                }));
+            }
+
+            for handle in handles {
+                handle.join().expect("worker thread panicked");
+            }
+        }
+
+        #[test]
+        fn ok_parallel_waiters_same_epoch() {
+            let completion = sync::Arc::new(ack::Completion::default());
+
+            let mut handles = Vec::new();
+            for _ in 0..0x10 {
+                let completion = completion.clone();
+
+                handles.push(thread::spawn(move || {
+                    let ticket = ack::AckTicket::new(1, completion);
+
+                    assert_eq!(
+                        futures::executor::block_on(ticket).expect("ticket must complete"),
+                        1
+                    );
+                }));
+            }
+
+            thread::sleep(time::Duration::from_millis(0x0A));
+
+            completion.mark_epoch_as_durable(1);
+            completion.notify_all_listeners();
+
+            for handle in handles {
+                handle.join().expect("worker thread panicked");
+            }
+        }
+    }
 }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -750,6 +750,61 @@ where
         self.core.file.delete()
     }
 
+    /// Flush the dirty mmap data to persistant storage
+    ///
+    /// *NOTE:* This call must be paired w/ [`FrozenMMap::flush_file`] for stronger durability
+    /// guarantee
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
+    ///
+    /// const MODULE_ID: u8 = 0;
+    ///
+    /// let dir = tempfile::tempdir().unwrap();
+    /// let path = dir.path().join("tmp_delete_mmap");
+    ///
+    /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
+    ///     initial_count: 0x04,
+    ///     flush_duration: std::time::Duration::from_micros(0x96),
+    /// };
+    ///
+    /// let mut mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
+    /// assert!(unsafe { mmap.flush_mmap() }.is_ok());
+    /// ```
+    #[inline]
+    pub unsafe fn flush_mmap(&self) -> FrozenResult<()> {
+        self.core.map.sync(self.core.curr_length)
+    }
+
+    /// Perform hard flush for the dirty mmap'ed data for stronger durability guarantee
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
+    ///
+    /// const MODULE_ID: u8 = 0;
+    ///
+    /// let dir = tempfile::tempdir().unwrap();
+    /// let path = dir.path().join("tmp_delete_mmap");
+    ///
+    /// let cfg = FrozenMMapCfg {
+    ///     module_id: MODULE_ID,
+    ///     initial_count: 0x04,
+    ///     flush_duration: std::time::Duration::from_micros(0x96),
+    /// };
+    ///
+    /// let mut mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
+    /// assert!(unsafe { mmap.flush_file() }.is_ok());
+    /// ```
+    #[inline]
+    pub unsafe fn flush_file(&self) -> FrozenResult<()> {
+        self.core.file.sync()
+    }
+
     #[inline]
     fn munmap(&self) -> FrozenResult<()> {
         let length = self.core.curr_length;

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -58,7 +58,8 @@
 mod posix;
 
 use crate::{
-    error::{FrozenError, FrozenResult},
+    ack,
+    error::FrozenResult,
     ffile::{FrozenFile, FrozenFileCfg},
     hints,
 };
@@ -111,8 +112,8 @@ pub(in crate::fmmap) mod err {
     /// no write/read perm
     pub const PRM: ErrCode = ErrCode::new(0x0A, "missing permissions for IO");
 
-    /// flush_tx error (panic inside)
-    pub const TXE: ErrCode = ErrCode::new(0x0C, "flush_tx paniced inside");
+    /// type `T` must not be zero sized
+    pub const ZRO: ErrCode = ErrCode::new(0x0C, "type T must not be zero sized");
 
     /// flush_tx error (unable to spawn)
     pub const FXE: ErrCode = ErrCode::new(0x10, "unable to spawn flush_tx");
@@ -125,9 +126,6 @@ pub(in crate::fmmap) mod err {
 
     /// `size_of::<T>()` is not multiple of 8
     pub const SZE: ErrCode = ErrCode::new(0x16, "`size_of::<T>()` must be multiple of 8 bytes");
-
-    /// type `T` must not be zero sized
-    pub const ZRO: ErrCode = ErrCode::new(0x18, "type T must not be zero sized");
 
     #[inline]
     pub(in crate::fmmap) fn new_err<R, E: std::fmt::Display>(
@@ -142,14 +140,6 @@ pub(in crate::fmmap) mod err {
     pub(in crate::fmmap) fn new_err_default<R>(code: ErrCode) -> FrozenResult<R> {
         let err = FrozenError::new_raw(*mid(), ERRDOMAIN, code, "");
         Err(err)
-    }
-
-    #[inline]
-    pub(in crate::fmmap) fn new_err_raw<E: std::fmt::Display>(
-        code: ErrCode,
-        error: E,
-    ) -> FrozenError {
-        FrozenError::new_raw(*mid(), ERRDOMAIN, code, error)
     }
 }
 
@@ -231,7 +221,7 @@ where
     T: Sized + Send + Sync,
 {
     core: sync::Arc<Core>,
-    tx: Option<thread::JoinHandle<()>>,
+    flush_tx_handle: Option<thread::JoinHandle<()>>,
     _t: core::marker::PhantomData<T>,
 }
 
@@ -310,13 +300,20 @@ where
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
-        let core =
-            sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
+        let core = sync::Arc::new(Core::new(mmap, file, curr_length, total_slots));
 
-        // INFO: we spawn the thread for background sync
-        let tx = Core::spawn_tx(core.clone())?;
+        let cloned_core = sync::Arc::clone(&core);
+        let flush_tx_handle = match thread::Builder::new()
+            .name(format!("mod{}_fmmap_flush_tx", cfg.module_id))
+            .spawn(move || bg_flush_thread(cloned_core, cfg.flush_duration))
+        {
+            Ok(handle) => Some(handle),
+            Err(observed_error) => {
+                return err::new_err(err::FXE, observed_error);
+            }
+        };
 
-        Ok(Self { core, tx: Some(tx), _t: core::marker::PhantomData })
+        Ok(Self { core, flush_tx_handle, _t: core::marker::PhantomData })
     }
 
     /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`], while growing the
@@ -397,13 +394,20 @@ where
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
-        let core =
-            sync::Arc::new(Core::new(mmap, file, cfg.flush_duration, curr_length, total_slots));
+        let core = sync::Arc::new(Core::new(mmap, file, curr_length, total_slots));
 
-        // INFO: we spawn the thread for background sync
-        let tx = Core::spawn_tx(core.clone())?;
+        let cloned_core = sync::Arc::clone(&core);
+        let flush_tx_handle = match thread::Builder::new()
+            .name(format!("mod{}_fmmap_flush_tx", cfg.module_id))
+            .spawn(move || bg_flush_thread(cloned_core, cfg.flush_duration))
+        {
+            Ok(handle) => Some(handle),
+            Err(observed_error) => {
+                return err::new_err(err::FXE, observed_error);
+            }
+        };
 
-        Ok(Self { core, tx: Some(tx), _t: core::marker::PhantomData })
+        Ok(Self { core, flush_tx_handle, _t: core::marker::PhantomData })
     }
 
     /// Create/open a new [`FrozenFile`] instance
@@ -445,67 +449,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Blocks until given `epoch` becomes durable
-    ///
-    /// ## Batching
-    ///
-    /// With respect to `flush_duration`, all write ops are batched before sync, which is executed
-    /// by flusher tx working in background, while each write is assigned w/ current durable epoch,
-    /// and all writes which observe the exact same epoch, belong to the same durability window, and
-    /// are all sync'ed together
-    ///
-    /// When a background sync succeeds, the internal durable epoch is incremented, indicating that
-    /// all writes that observed the previous epoch are now durable on disk
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
-    ///
-    /// const MODULE_ID: u8 = 0;
-    ///
-    /// let dir = tempfile::tempdir().unwrap();
-    /// let path = dir.path().join("tmp_wait_epoch");
-    ///
-    /// let cfg = FrozenMMapCfg {
-    ///     module_id: MODULE_ID,
-    ///     initial_count: 0x04,
-    ///     flush_duration: std::time::Duration::from_micros(0x60),
-    /// };
-    ///
-    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
-    ///
-    /// let epoch = unsafe { mmap.write(0, |v| *v = 0x8A) }.unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
-    ///
-    /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
-    /// assert_eq!(val, 0x8A);
-    /// ```
-    pub fn wait_for_durability(&self, epoch: u64) -> FrozenResult<()> {
-        if let Some(sync_err) = self.core.get_sync_error() {
-            return Err(sync_err);
-        }
-
-        let durable_epoch = self.core.durable_epoch.load(atomic::Ordering::Acquire);
-        if durable_epoch >= epoch {
-            return Ok(());
-        }
-
-        let mut guard = self.core.acquire_durable_lock();
-        loop {
-            if let Some(sync_err) = self.core.get_sync_error() {
-                return Err(sync_err);
-            }
-
-            if self.core.durable_epoch.load(atomic::Ordering::Acquire) >= epoch {
-                return Ok(());
-            }
-
-            // NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
-            guard = self.core.durable_cv.wait(guard).unwrap_or_else(|e| e.into_inner());
-        }
     }
 
     /// Read a `T` at given `index` via callback (`f`)
@@ -609,7 +552,7 @@ where
     #[inline(always)]
     pub unsafe fn write(&self, index: usize, f: impl FnOnce(*mut T)) -> FrozenResult<TEpoch> {
         // propagate prev errors
-        if let Some(err) = self.core.get_sync_error() {
+        if let Some(err) = self.core.completion.get_err() {
             return Err(err);
         }
 
@@ -622,90 +565,9 @@ where
         f(ptr);
 
         self.core.dirty.store(true, atomic::Ordering::Release);
-        let epoch = self.core.incr_curr_epoch();
+        let epoch = self.core.completion.increment_current_epoch();
 
         Ok(epoch)
-    }
-
-    /// Write/update a `T` at given `index` via callback (`f`) w/ instant durability
-    ///
-    /// This function performs a blocking hard-sync, unlike [`FrozenMMap::write`], the update is
-    /// immediately persisted to the underlying storage device
-    ///
-    /// ## Concurrency
-    ///
-    /// Internally, [`FrozenMMap`] implements per-slot locking, so concurrent reads and writes for
-    /// at same index is atomic and thread safe, while operations on different indices may proceed
-    /// fully in parallel.
-    ///
-    /// ## Safety
-    ///
-    /// The caller must ensure following:
-    ///
-    /// - given `index` is within bounds
-    /// - underlying memory contains a valid instance of `T`
-    /// - provided callback `f` must not  store or leak pointer beyound there lifetime
-    ///
-    /// Violating any of the above may result in undefined behavior
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// use frozen_core::fmmap::{FrozenMMap, FrozenMMapCfg};
-    ///
-    /// const MODULE_ID: u8 = 0;
-    ///
-    /// let dir = tempfile::tempdir().unwrap();
-    /// let path = dir.path().join("tmp_write_sync");
-    ///
-    /// let cfg = FrozenMMapCfg {
-    ///     module_id: MODULE_ID,
-    ///     initial_count: 0x02,
-    ///     flush_duration: std::time::Duration::from_micros(0x96),
-    /// };
-    ///
-    /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
-    /// unsafe { mmap.write_sync(0, |v| *v = 0xC0DE) }.unwrap();
-    ///
-    /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
-    /// assert_eq!(val, 0xC0DE);
-    /// ```
-    #[inline(always)]
-    pub unsafe fn write_sync(&self, index: usize, f: impl FnOnce(*mut T)) -> FrozenResult<()> {
-        // propagate prev errors
-        if let Some(err) = self.core.get_sync_error() {
-            return Err(err);
-        }
-
-        let offset = Self::SLOT_SIZE * index;
-
-        // block flush_tx scheduling
-        let _flush_guard = self.core.acquire_lock();
-
-        // we use exlusive lock as we perform blocking hard sync
-        let _guard = self.core.acquire_exclusive_io_lock();
-
-        let _lock = self.core.locks.lock(index);
-        let ptr = unsafe { self.core.map.as_mut_ptr(offset) };
-        f(ptr);
-
-        // blocking hard sync
-        self.core.sync()?;
-
-        // NOTE: we hard sync we flushed an entier batch, so we can skip the sync via flush_tx as
-        // the current batch is durable
-
-        self.core.mark_epoch_durable();
-        let prev = self.core.dirty.swap(false, atomic::Ordering::AcqRel);
-
-        // NOTE: we must also notify cv's waiting for durability (we skip if there was no batch to
-        // sync)
-        if prev {
-            let _g = self.core.acquire_durable_lock();
-            self.core.durable_cv.notify_all();
-        }
-
-        Ok(())
     }
 
     /// Read current available count of slots, where each slot has size of [`FrozenMMap::<T>::SLOT_SIZE`]
@@ -873,7 +735,7 @@ where
         self.core.closed.store(true, atomic::Ordering::Release);
         self.core.durable_cv.notify_one();
 
-        if let Some(handle) = self.tx.take() {
+        if let Some(handle) = self.flush_tx_handle.take() {
             let _ = handle.join();
         }
 
@@ -899,20 +761,12 @@ where
         let is_closed = self.core.closed.swap(true, atomic::Ordering::Release);
         self.core.cv.notify_one(); // notify flusher tx to shut
 
-        if let Some(handle) = self.tx.take() {
+        if let Some(handle) = self.flush_tx_handle.take() {
             let _ = handle.join();
         }
 
         // we must acquire an exclusive lock, to prevent dropping while sync, growing or any io ops
         let _io_lock = self.core.acquire_exclusive_io_lock();
-
-        // free up the boxed error (if any)
-        let ptr = self.core.error.swap(std::ptr::null_mut(), atomic::Ordering::AcqRel);
-        if !ptr.is_null() {
-            unsafe {
-                drop(Box::from_raw(ptr));
-            }
-        }
 
         if !is_closed {
             let _ = self.munmap();
@@ -932,6 +786,80 @@ where
             self.total_slots(),
             self.core.curr_length,
         )
+    }
+}
+
+/// ## Why we ignore [`std::sync::PoisonError`]?
+///
+/// The mutex used for lock, is solely used as a parking primitive for [`Condvar`] and does not
+/// protect any mutable state. All the pool invariants and accounting are maintained via atomics
+/// and are completely seperated from the mutex.
+///
+/// A poisoned mutex only indicates that another tx panicked while holding the lock, and indicates
+/// an inconsistent state of the protected value. Since no state can be left partially modified
+/// under this lock, there is no possible consistency risk to recover from and propagating the
+/// poison error would only introduce unnecessary failures into the allocation path.
+///
+/// Therefore, as best effort, we consume the [`std::sync::PoisonError`] and continue operating
+/// with the recovered guard.
+fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
+    // init phase (acquiring locks)
+    let mut guard = core.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+    // sync loop w/ non-busy waiting
+    loop {
+        (guard, _) = core.cv.wait_timeout(guard, flush_duration).unwrap_or_else(|e| e.into_inner());
+
+        // NOTE: we must read values of close brodcast before acquire exclusive lock, if done
+        // otherwise, we impose serious deadlock sort of situation for the the flusher tx
+
+        let dirty = core.dirty.swap(false, atomic::Ordering::AcqRel);
+        let closing = core.closed.load(atomic::Ordering::Acquire);
+
+        if !dirty {
+            if closing {
+                core.cv.notify_all();
+                return;
+            }
+
+            continue;
+        }
+
+        // INFO: we must acquire an exclusive IO lock for sync, hence no write, read or
+        // grow could kick in while sync is in progress
+
+        let io_lock = core.acquire_exclusive_io_lock();
+
+        // INFO: we must drop the guard before syscall, as its a blocking operation and holding
+        // the mutex while the syscall takes place is not a good idea, while we drop the mutex
+        // and acqurie it again, in-between other process could acquire it and use it
+        drop(guard);
+
+        // NOTE: We snapshot `current_epoch` before sync to establish a strict batch boundary,
+        // all writes up to `target_epoch` are guaranteed to be part of this flush window,
+        // while anything beyound belongs to the next batch
+        let target_epoch = core.completion.read_current_epoch();
+
+        // NOTE:
+        //
+        // - if sync fails, we update the Core::error w/ the received error object
+        // - we clear it up when another sync call succeeds
+        // - this is valid, as the underlying sync flushes entire mmaped region, hence
+        //   even if the last call failed, and the new one succeeded, we do get the durability
+        //   guarenty for the old data as well
+
+        if let Err(new_error) = core.sync() {
+            core.completion.set_err(new_error);
+        } else {
+            core.completion.mark_epoch_as_durable(target_epoch);
+            core.completion.del_err();
+        }
+
+        // NOTE: notify all listeners currently waiting for durability progress
+        core.completion.notify_all_listeners();
+
+        drop(io_lock);
+        guard = core.acquire_lock();
     }
 }
 
@@ -1095,7 +1023,7 @@ impl<'a, T> FMTransaction<'a, T> {
     /// ```
     #[inline(always)]
     pub fn commit(self) -> FrozenResult<u64> {
-        if let Some(err) = self.core.get_sync_error() {
+        if let Some(err) = self.core.completion.get_err() {
             return Err(err);
         }
 
@@ -1114,7 +1042,7 @@ impl<'a, T> FMTransaction<'a, T> {
         }
 
         self.core.dirty.store(true, atomic::Ordering::Release);
-        let epoch = self.core.incr_curr_epoch();
+        let epoch = self.core.completion.increment_current_epoch();
 
         Ok(epoch)
     }
@@ -1122,50 +1050,36 @@ impl<'a, T> FMTransaction<'a, T> {
 
 #[derive(Debug)]
 struct Core {
-    map: TMap,
-    locks: Locks,
-    file: FrozenFile,
+    completion: ack::Completion,
     cv: sync::Condvar,
     curr_length: usize,
-    lock: sync::Mutex<()>,
-    io_lock: sync::RwLock<()>,
     dirty: atomic::AtomicBool,
+    io_lock: sync::RwLock<()>,
+    map: TMap,
+    locks: Locks,
+    lock: sync::Mutex<()>,
+    file: FrozenFile,
     durable_cv: sync::Condvar,
     closed: atomic::AtomicBool,
-    durable_lock: sync::Mutex<()>,
-    flush_duration: time::Duration,
-    current_epoch: atomic::AtomicU64,
-    durable_epoch: atomic::AtomicU64,
-    error: atomic::AtomicPtr<sync::Arc<FrozenError>>,
 }
 
 unsafe impl Send for Core {}
 unsafe impl Sync for Core {}
 
 impl Core {
-    fn new(
-        map: TMap,
-        file: FrozenFile,
-        flush_duration: time::Duration,
-        curr_length: usize,
-        total_slots: usize,
-    ) -> Self {
+    fn new(map: TMap, file: FrozenFile, curr_length: usize, total_slots: usize) -> Self {
         Self {
             map,
             file,
             curr_length,
-            flush_duration,
+            completion: ack::Completion::default(),
             cv: sync::Condvar::new(),
             lock: sync::Mutex::new(()),
             io_lock: sync::RwLock::new(()),
             locks: Locks::new(total_slots),
             durable_cv: sync::Condvar::new(),
-            durable_lock: sync::Mutex::new(()),
             dirty: atomic::AtomicBool::new(false),
             closed: atomic::AtomicBool::new(false),
-            current_epoch: atomic::AtomicU64::new(0),
-            durable_epoch: atomic::AtomicU64::new(0),
-            error: atomic::AtomicPtr::new(std::ptr::null_mut()),
         }
     }
 
@@ -1175,171 +1089,22 @@ impl Core {
         self.file.sync()
     }
 
-    #[inline(always)]
-    fn set_sync_error(&self, err: FrozenError) {
-        let boxed = Box::into_raw(Box::new(sync::Arc::new(err)));
-        let old = self.error.swap(boxed, atomic::Ordering::AcqRel);
-
-        // NOTE: we must free the old error, if any, to avoid mem leaks
-        if !old.is_null() {
-            unsafe { drop(Box::from_raw(old)) };
-        }
-    }
-
-    #[inline(always)]
-    fn get_sync_error(&self) -> Option<FrozenError> {
-        let ptr = self.error.load(atomic::Ordering::Acquire);
-        if hints::likely(ptr.is_null()) {
-            return None;
-        }
-
-        let arc = unsafe { &*ptr }.clone();
-        Some((*arc).clone())
-    }
-
-    #[inline]
-    fn clear_sync_error(&self) {
-        let old = self.error.swap(std::ptr::null_mut(), atomic::Ordering::AcqRel);
-        if hints::unlikely(!old.is_null()) {
-            unsafe {
-                drop(Box::from_raw(old));
-            }
-        }
-    }
-
-    /// ## Why we ignore [`std::sync::PoisonError`]?
-    ///
-    /// The mutex used for lock, is solely used as a parking primitive for [`Condvar`] and does not
-    /// protect any mutable state. All the pool invariants and accounting are maintained via atomics
-    /// and are completely seperated from the mutex.
-    ///
-    /// A poisoned mutex only indicates that another tx panicked while holding the lock, and indicates
-    /// an inconsistent state of the protected value. Since no state can be left partially modified
-    /// under this lock, there is no possible consistency risk to recover from and propagating the
-    /// poison error would only introduce unnecessary failures into the allocation path.
-    ///
-    /// Therefore, as best effort, we consume the [`std::sync::PoisonError`] and continue operating
-    /// with the recovered guard.
-    #[inline]
-    fn acquire_durable_lock(&self) -> sync::MutexGuard<'_, ()> {
-        self.durable_lock.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
-    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+    /// NOTE: See [`bg_flush_thread`] implementation for rationale behind poison recovery
     #[inline]
     fn acquire_lock(&self) -> sync::MutexGuard<'_, ()> {
         self.lock.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+    /// NOTE: See [`bg_flush_thread`] implementation for rationale behind poison recovery
     #[inline]
     fn acquire_io_lock(&self) -> sync::RwLockReadGuard<'_, ()> {
         self.io_lock.read().unwrap_or_else(|e| e.into_inner())
     }
 
-    /// NOTE: See [`Core::acquire_durable_lock`] implementation for rationale behind poison recovery
+    /// NOTE: See [`bg_flush_thread`] implementation for rationale behind poison recovery
     #[inline]
     fn acquire_exclusive_io_lock(&self) -> sync::RwLockWriteGuard<'_, ()> {
         self.io_lock.write().unwrap_or_else(|e| e.into_inner())
-    }
-
-    #[inline]
-    fn incr_curr_epoch(&self) -> u64 {
-        self.current_epoch.fetch_add(1, atomic::Ordering::Release) + 1
-    }
-
-    #[inline]
-    fn mark_epoch_durable(&self) {
-        let curr_epoch = self.current_epoch.load(atomic::Ordering::Acquire);
-        self.durable_epoch.store(curr_epoch, atomic::Ordering::Release);
-    }
-
-    fn spawn_tx(core: sync::Arc<Self>) -> FrozenResult<thread::JoinHandle<()>> {
-        match thread::Builder::new().name("fm-flush-tx".into()).spawn(move || Self::flush_tx(core))
-        {
-            Ok(tx) => Ok(tx),
-            Err(error) => err::new_err(err::FXE, error),
-        }
-    }
-
-    fn flush_tx(core: sync::Arc<Self>) {
-        // init phase (acquiring locks)
-        let mut guard = match core.lock.lock() {
-            Ok(g) => g,
-            Err(error) => {
-                core.set_sync_error(err::new_err_raw(err::FXE, error));
-                core.cv.notify_all();
-                return;
-            }
-        };
-
-        // sync loop w/ non-busy waiting
-        loop {
-            guard = match core.cv.wait_timeout(guard, core.flush_duration) {
-                Ok((g, _)) => g,
-                Err(e) => {
-                    core.set_sync_error(err::new_err_raw(err::TXE, e));
-                    core.cv.notify_all();
-                    return;
-                }
-            };
-
-            // NOTE: we must read values of close brodcast before acquire exclusive lock, if done
-            // otherwise, we impose serious deadlock sort of situation for the the flusher tx
-
-            let dirty = core.dirty.swap(false, atomic::Ordering::AcqRel);
-            let closing = core.closed.load(atomic::Ordering::Acquire);
-
-            if !dirty {
-                if closing {
-                    core.cv.notify_all();
-                    return;
-                }
-
-                continue;
-            }
-
-            // INFO: we must acquire an exclusive IO lock for sync, hence no write, read or
-            // grow could kick in while sync is in progress
-
-            let io_lock = core.acquire_exclusive_io_lock();
-
-            // INFO: we must drop the guard before syscall, as its a blocking operation and holding
-            // the mutex while the syscall takes place is not a good idea, while we drop the mutex
-            // and acqurie it again, in-between other process could acquire it and use it
-            drop(guard);
-
-            // NOTE: We snapshot `current_epoch` before sync to establish a strict batch boundary,
-            // all writes up to `target_epoch` are guaranteed to be part of this flush window,
-            // while anything beyound belongs to the next batch
-            let target_epoch = core.current_epoch.load(atomic::Ordering::Acquire);
-
-            // NOTE:
-            //
-            // - if sync fails, we update the Core::error w/ the received error object
-            // - we clear it up when another sync call succeeds
-            // - this is valid, as the underlying sync flushes entire mmaped region, hence
-            //   even if the last call failed, and the new one succeeded, we do get the durability
-            //   guarenty for the old data as well
-
-            match core.sync() {
-                Ok(_) => {
-                    core.durable_epoch.store(target_epoch, atomic::Ordering::Release);
-
-                    let _g = core.acquire_durable_lock();
-
-                    core.clear_sync_error();
-                    core.durable_cv.notify_all();
-                }
-                Err(err) => {
-                    core.set_sync_error(err);
-                    core.durable_cv.notify_all();
-                }
-            }
-
-            drop(io_lock);
-            guard = core.acquire_lock();
-        }
     }
 }
 

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -550,7 +550,11 @@ where
     /// assert_eq!(val, 0x2B);
     /// ```
     #[inline(always)]
-    pub unsafe fn write(&self, index: usize, f: impl FnOnce(*mut T)) -> FrozenResult<TEpoch> {
+    pub unsafe fn write(
+        &self,
+        index: usize,
+        f: impl FnOnce(*mut T),
+    ) -> FrozenResult<ack::AckTicket> {
         // propagate prev errors
         if let Some(err) = self.core.completion.get_err() {
             return Err(err);
@@ -567,7 +571,7 @@ where
         self.core.dirty.store(true, atomic::Ordering::Release);
         let epoch = self.core.completion.increment_current_epoch();
 
-        Ok(epoch)
+        Ok(ack::AckTicket::new(epoch, self.core.completion.clone()))
     }
 
     /// Read current available count of slots, where each slot has size of [`FrozenMMap::<T>::SLOT_SIZE`]
@@ -1022,7 +1026,7 @@ impl<'a, T> FMTransaction<'a, T> {
     /// assert_eq!((v0, v1), (0x0A, 0x0C));
     /// ```
     #[inline(always)]
-    pub fn commit(self) -> FrozenResult<u64> {
+    pub fn commit(self) -> FrozenResult<ack::AckTicket> {
         if let Some(err) = self.core.completion.get_err() {
             return Err(err);
         }
@@ -1044,13 +1048,13 @@ impl<'a, T> FMTransaction<'a, T> {
         self.core.dirty.store(true, atomic::Ordering::Release);
         let epoch = self.core.completion.increment_current_epoch();
 
-        Ok(epoch)
+        Ok(ack::AckTicket::new(epoch, self.core.completion.clone()))
     }
 }
 
 #[derive(Debug)]
 struct Core {
-    completion: ack::Completion,
+    completion: sync::Arc<ack::Completion>,
     cv: sync::Condvar,
     curr_length: usize,
     dirty: atomic::AtomicBool,
@@ -1072,7 +1076,7 @@ impl Core {
             map,
             file,
             curr_length,
-            completion: ack::Completion::default(),
+            completion: sync::Arc::new(ack::Completion::default()),
             cv: sync::Condvar::new(),
             lock: sync::Mutex::new(()),
             io_lock: sync::RwLock::new(()),
@@ -1208,18 +1212,23 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
             let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
-            assert_eq!(mmap.core.flush_duration, FLUSH_DURATION);
             assert!(!mmap.core.dirty.load(atomic::Ordering::Acquire));
             assert!(!mmap.core.closed.load(atomic::Ordering::Acquire));
-            assert_eq!(mmap.core.durable_epoch.load(atomic::Ordering::Acquire), 0);
             assert_eq!(mmap.core.curr_length, INIT_SLOTS * FrozenMMap::<u64>::SLOT_SIZE);
 
+            assert_eq!(mmap.core.completion.read_current_epoch(), 0);
+            assert_eq!(mmap.core.completion.read_durable_epoch(), 0);
+
             // satisfies the bg thread was spawned correctly
-            assert!(mmap.core.error.load(atomic::Ordering::Acquire).is_null());
+            assert!(mmap.core.completion.get_err().is_none());
 
             // satisfies wait on epoch works
-            let epoch = unsafe { mmap.write(0, |f| *f = 0x0A).unwrap() };
-            assert!(mmap.wait_for_durability(epoch).is_ok());
+            let ticket = unsafe { mmap.write(0, |f| *f = 0x0A).unwrap() };
+
+            let ticket_epoch = ticket.epoch();
+            let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+            assert!(durable_epoch >= ticket_epoch);
         }
 
         #[test]
@@ -1501,8 +1510,12 @@ mod tests {
             let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             // write + sync
-            let epoch = unsafe { mmap.write(0, |ptr| *ptr = VAL).unwrap() };
-            mmap.wait_for_durability(epoch).unwrap();
+            let ticket = unsafe { mmap.write(0, |ptr| *ptr = VAL).unwrap() };
+
+            let ticket_epoch = ticket.epoch();
+            let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+            assert!(durable_epoch >= ticket_epoch);
 
             // read + verify
             let val = unsafe { mmap.read(0, |ptr| *ptr).unwrap() };
@@ -1521,79 +1534,6 @@ mod tests {
         }
     }
 
-    mod fm_write_sync_read {
-        use super::*;
-
-        #[test]
-        fn ok_write_sync_read() {
-            let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
-
-            unsafe { mmap.write_sync(0, |v| *v = 0x4C).unwrap() };
-
-            let val = unsafe { mmap.read(0, |v| *v).unwrap() };
-            assert_eq!(val, 0x4C);
-        }
-
-        #[test]
-        fn ok_write_sync_wait_returns_immediately() {
-            let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
-
-            let _ = unsafe { mmap.write_sync(0, |v| *v = 0x6A).unwrap() };
-
-            let val = unsafe { mmap.read(0, |v| *v).unwrap() };
-            assert_eq!(val, 0x6A);
-        }
-
-        #[test]
-        fn ok_write_sync_followed_by_async_write() {
-            let (_dir, path, cfg) = new_tmp();
-
-            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
-            unsafe { mmap.write_sync(0, |v| *v = 0x0A).unwrap() };
-
-            let epoch = unsafe { mmap.write(0, |v| *v = 0x14).unwrap() };
-            mmap.wait_for_durability(epoch).unwrap();
-
-            let val = unsafe { mmap.read(0, |v| *v).unwrap() };
-            assert_eq!(val, 0x14);
-        }
-
-        #[test]
-        fn ok_write_sync_makes_prev_batch_durable() {
-            let (_dir, path, cfg) = new_tmp();
-            let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
-
-            let async_epoch = unsafe { mmap.write(0, |v| *v = 1).unwrap() };
-            unsafe { mmap.write_sync(1, |v| *v = 2).unwrap() };
-            mmap.wait_for_durability(async_epoch).unwrap();
-
-            let v1 = unsafe { mmap.read(0, |v| *v).unwrap() };
-            let v2 = unsafe { mmap.read(1, |v| *v).unwrap() };
-
-            assert_eq!(v1, 1);
-            assert_eq!(v2, 2);
-        }
-
-        #[test]
-        fn ok_write_sync_persists_across_reopen() {
-            let (_dir, path, cfg) = new_tmp();
-            const VAL: u64 = 0x1000;
-
-            {
-                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
-                unsafe { mmap.write_sync(0, |v| *v = VAL).unwrap() };
-            }
-
-            {
-                let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
-                let val = unsafe { mmap.read(0, |v| *v).unwrap() };
-                assert_eq!(val, VAL);
-            }
-        }
-    }
-
     mod fm_tx {
         use super::*;
 
@@ -1609,8 +1549,12 @@ mod tests {
                 tx.write(2, |v| *v = 3).unwrap();
             }
 
-            let epoch = tx.commit().unwrap();
-            mmap.wait_for_durability(epoch).unwrap();
+            let ticket = tx.commit().unwrap();
+
+            let ticket_epoch = ticket.epoch();
+            let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+            assert!(durable_epoch >= ticket_epoch);
 
             let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
             let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
@@ -1632,10 +1576,10 @@ mod tests {
 
             // NOTE: next write must have strictly higher epoch then current one
 
-            let epoch = tx.commit().unwrap();
-            let next_epoch = unsafe { mmap.write(2, |v| *v = 0x1E).unwrap() };
+            let ticket = tx.commit().unwrap();
+            let next_ticket = unsafe { mmap.write(2, |v| *v = 0x1E).unwrap() };
 
-            assert!(next_epoch > epoch);
+            assert!(next_ticket.epoch() > ticket.epoch());
         }
 
         #[test]
@@ -1680,8 +1624,12 @@ mod tests {
                         tx.write(i * 2 + 1, |v| *v = i as u64).unwrap();
                     }
 
-                    let epoch = tx.commit().unwrap();
-                    mmap.wait_for_durability(epoch).unwrap();
+                    let ticket = tx.commit().unwrap();
+
+                    let ticket_epoch = ticket.epoch();
+                    let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+                    assert!(durable_epoch >= ticket_epoch);
                 }));
             }
 
@@ -1714,8 +1662,12 @@ mod tests {
                 tx2.write(0, |v| *v = 2).unwrap();
             }
 
-            let epoch = tx2.commit().unwrap();
-            mmap.wait_for_durability(epoch).unwrap();
+            let ticket = tx2.commit().unwrap();
+
+            let ticket_epoch = ticket.epoch();
+            let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+            assert!(durable_epoch >= ticket_epoch);
 
             let val = unsafe { mmap.read(0, |v| *v).unwrap() };
             assert_eq!(val, 2);
@@ -1734,8 +1686,12 @@ mod tests {
                     tx.write(1, |v| *v = 0x54).unwrap();
                 }
 
-                let epoch = tx.commit().unwrap();
-                mmap.wait_for_durability(epoch).unwrap();
+                let ticket = tx.commit().unwrap();
+
+                let ticket_epoch = ticket.epoch();
+                let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+                assert!(durable_epoch >= ticket_epoch);
             }
 
             {
@@ -1757,8 +1713,12 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
             let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
-            let epoch = unsafe { mmap.write(0, |v| *v = 7).unwrap() };
-            mmap.wait_for_durability(epoch).unwrap();
+            let ticket = unsafe { mmap.write(0, |v| *v = 7).unwrap() };
+
+            let ticket_epoch = ticket.epoch();
+            let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+            assert!(durable_epoch >= ticket_epoch);
 
             drop(mmap);
         }
@@ -1768,12 +1728,11 @@ mod tests {
             let (_dir, path, cfg) = new_tmp();
             let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
-            let e1 = unsafe { mmap.write(0, |v| *v = 1).unwrap() };
-            mmap.wait_for_durability(e1).unwrap();
+            let t1 = unsafe { mmap.write(0, |v| *v = 1).unwrap() };
+            let t2 = unsafe { mmap.write(0, |v| *v = 2).unwrap() };
 
-            let e2 = unsafe { mmap.write(0, |v| *v = 2).unwrap() };
-            mmap.wait_for_durability(e2).unwrap();
-            assert!(e2 >= e1);
+            let durable_epoch = futures::executor::block_on(t2).unwrap();
+            assert!(durable_epoch >= t1.epoch());
         }
 
         #[test]
@@ -1785,8 +1744,12 @@ mod tests {
             for _ in 0..2 {
                 let mmap = mmap.clone();
                 handles.push(thread::spawn(move || {
-                    let epoch = unsafe { mmap.write(0, |v| *v += 1).unwrap() };
-                    mmap.wait_for_durability(epoch).unwrap();
+                    let ticket = unsafe { mmap.write(0, |v| *v += 1).unwrap() };
+
+                    let ticket_epoch = ticket.epoch();
+                    let durable_epoch = futures::executor::block_on(ticket).unwrap();
+
+                    assert!(durable_epoch >= ticket_epoch);
                 }));
             }
 

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -39,8 +39,8 @@
 //! let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 //! assert_eq!(mmap.total_slots(), 0x0A);
 //!
-//! let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
-//! mmap.wait_for_durability(epoch).unwrap();
+//! let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
+//! let _ = futures::executor::block_on(ticket).unwrap();
 //!
 //! let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
 //! assert_eq!(val, 0xDEADC0DE);
@@ -201,8 +201,8 @@ pub struct FrozenMMapCfg {
 /// let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
 /// assert_eq!(mmap.total_slots(), 0x0A);
 ///
-/// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
-/// mmap.wait_for_durability(epoch).unwrap();
+/// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
+/// let _ = futures::executor::block_on(ticket).unwrap();
 ///
 /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
 /// assert_eq!(val, 0xDEADC0DE);
@@ -284,8 +284,8 @@ where
     /// let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x0A);
     ///
-    /// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
     /// assert_eq!(val, 0xDEADC0DE);
@@ -370,8 +370,8 @@ where
     /// let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x0A).unwrap();
     /// assert_eq!(mmap.total_slots(), 0x0A * 2);
     ///
-    /// let epoch = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
     /// assert_eq!(val, 0xDEADC0DE);
@@ -489,8 +489,8 @@ where
     ///
     /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
-    /// let epoch = unsafe { mmap.write(0, |v| *v = 0x0A) }.unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = unsafe { mmap.write(0, |v| *v = 0x0A) }.unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
     /// assert_eq!(val, 0x0A);
@@ -543,8 +543,8 @@ where
     ///
     /// let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
     ///
-    /// let epoch = unsafe {mmap.write(1, |v| *v = 0x2B) }.unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = unsafe {mmap.write(1, |v| *v = 0x2B) }.unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let val = unsafe { mmap.read(1, |v| *v) }.unwrap();
     /// assert_eq!(val, 0x2B);
@@ -684,8 +684,8 @@ where
     /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
     /// unsafe { tx.write(1, |v| *v = 0x14) }.unwrap();
     ///
-    /// let epoch = tx.commit().unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = tx.commit().unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
     /// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
@@ -900,8 +900,8 @@ fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
 /// unsafe { tx.write(1, |v| *v = 0x14) }.unwrap();
 /// unsafe { tx.write(2, |v| *v = 0x18) }.unwrap();
 ///
-/// let epoch = tx.commit().unwrap();
-/// mmap.wait_for_durability(epoch).unwrap();
+/// let ticket = tx.commit().unwrap();
+/// let _ = futures::executor::block_on(ticket).unwrap();
 ///
 /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
 /// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
@@ -953,8 +953,8 @@ impl<'a, T> FrozenMMapTransaction<'a, T> {
     /// unsafe { tx.write(1, |v| *v = 0x0B) }.unwrap();
     /// unsafe { tx.write(2, |v| *v = 0x0C) }.unwrap();
     ///
-    /// let epoch = tx.commit().unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = tx.commit().unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
     /// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
@@ -1017,8 +1017,8 @@ impl<'a, T> FrozenMMapTransaction<'a, T> {
     /// unsafe { tx.write(0, |v| *v = 0x0A) }.unwrap();
     /// unsafe { tx.write(2, |v| *v = 0x0C) }.unwrap();
     ///
-    /// let epoch = tx.commit().unwrap();
-    /// mmap.wait_for_durability(epoch).unwrap();
+    /// let ticket = tx.commit().unwrap();
+    /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
     /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
     /// let v1 = unsafe { mmap.read(2, |v| *v).unwrap() };

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -648,12 +648,12 @@ where
         mmap_bytes + lock_bytes
     }
 
-    /// Create a new [`FMTransaction`] context for grouping multi write ops into a single atomic
+    /// Create a new [`FrozenMMapTransaction`] context for grouping multi write ops into a single atomic
     /// operation
     ///
     /// ## Overview
     ///
-    /// The use of [`FMTransaction`] allows to group multiple write ops into a single atomic
+    /// The use of [`FrozenMMapTransaction`] allows to group multiple write ops into a single atomic
     /// operation, hence creating a transactional write operation, which gives following guarantees:
     ///
     /// - All write ops succeed together
@@ -693,8 +693,8 @@ where
     /// assert_eq!((v0, v1), (0x0A, 0x14));
     /// ```
     #[inline]
-    pub fn new_tx(&self) -> FMTransaction<'_, T> {
-        FMTransaction { core: &self.core, ops_vec: Vec::new() }
+    pub fn new_tx(&self) -> FrozenMMapTransaction<'_, T> {
+        FrozenMMapTransaction { core: &self.core, ops_vec: Vec::new() }
     }
 
     /// Delete the underlying [`FrozenFile`] used for [`FrozenMMap`] from fs
@@ -871,7 +871,7 @@ fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
 ///
 /// ## Overview
 ///
-/// Use of [`FMTransaction`] allows to group multiple write ops into a single atomic operation.
+/// Use of [`FrozenMMapTransaction`] allows to group multiple write ops into a single atomic operation.
 ///
 /// - All included writes are applied together
 /// - Single epoch is assinged for an entier transaction
@@ -909,13 +909,13 @@ fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
 ///
 /// assert_eq!((v0, v1, v2), (0x0A, 0x14, 0x18));
 /// ```
-pub struct FMTransaction<'a, T> {
+pub struct FrozenMMapTransaction<'a, T> {
     core: &'a Core,
     ops_vec: Vec<(usize, Box<dyn FnOnce(*mut T) + 'a>)>,
 }
 
-impl<'a, T> FMTransaction<'a, T> {
-    /// Append a write op into the [`FMTransaction`]
+impl<'a, T> FrozenMMapTransaction<'a, T> {
+    /// Append a write op into the [`FrozenMMapTransaction`]
     ///
     /// ## Requirements
     ///


### PR DESCRIPTION
Completed #57