### PR TITLE
Added build targets metadata for `docs.rs` build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `0.0.28`
+
+- Added build targets metadata for `docs.rs` build (#65)
+
 ## `0.0.27`
 
 - Implementation of immediate durability mode for the rare write workloads (#63)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frozen-core"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "criterion",
  "event-listener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ exclude = [
     "CODE_OF_CONDUCT.md",
 ]
 
+[package.metadata.docs.rs]
+default-target = "x86_64-unknown-linux-gnu"
+targets = ["aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]
+additional-targets = ["i686-apple-darwin"]
+
 [profile.release]
 codegen-units = 1
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2024"
-version = "0.0.27"
+version = "0.0.28"
 name = "frozen-core"
 readme = "README.md"
 rust-version = "1.86.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add following to your `Cargo.toml`,
 
 ```toml
 [dependencies]
-frozen-core = { version = "0.0.27", default-features = true }
+frozen-core = { version = "0.0.28", default-features = true }
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Release of `0.0.28`

## Changelog

- Completed #65

## Ready?

- [x] All unit tests passing
- [x] All doctests passing
- [x] No lints or warnings
- [x] Updated README
- [x] Updated CHANGELOG
- [x] Version bump
