### PR TITLE
(fmmap) fixed the `FrozenMMap::delete` incorrectly clearing the `dirty` flag

### DIFF
--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -774,9 +774,7 @@ where
     /// ```
     pub fn delete(&mut self) -> FrozenResult<()> {
         // NOTE: we must broadcast that the close is happening to allow flusher tx to wrap up
-        self.core.dirty.store(false, atomic::Ordering::Release);
         self.core.closed.store(true, atomic::Ordering::Release);
-
         if let Some(handle) = self.flush_tx_handle.take() {
             let _ = handle.join();
         }


### PR DESCRIPTION
Fixed the #79