### PR TITLE
release of `v0.0.30`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## `0.0.30`
+
+- Updated api signature of `FrozenMMap::read()` (#75)
+- Fixed dishonore of `immediate_durability` in `FrozenMMapCfg` (#76)
+- Impl of `AckTicket::wait()` for internal blocking (#77)
+- Remove the stale `durable_cv` from `FrozenMMap -> Core` (#78)
+- Fixed `FrozenMMap::delete()` to avoid incorrectly updating `dirty` flag (#79)
+
 ## `0.0.29`
 
 - Impl of `reservoir` module (#67)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "frozen-core"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "criterion",
  "event-listener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2024"
-version = "0.0.29"
+version = "0.0.30"
 name = "frozen-core"
 readme = "README.md"
 rust-version = "1.86.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add following to your `Cargo.toml`,
 
 ```toml
 [dependencies]
-frozen-core = { version = "0.0.29", default-features = true }
+frozen-core = { version = "0.0.30", default-features = true }
 ```
 
 > [!NOTE]

--- a/src/ack.rs
+++ b/src/ack.rs
@@ -25,6 +25,7 @@ use crate::{
     error::{FrozenError, FrozenResult},
     hints,
 };
+use event_listener::{Event, EventListener, Listener};
 use std::{future, pin, ptr, sync, sync::atomic, task};
 
 /// A monotomically increasing epoch used as indentifier for tracking durability of write operations
@@ -72,7 +73,7 @@ pub struct Completion {
     current_epoch: atomic::AtomicU64,
     durable_epoch: atomic::AtomicU64,
     error: AckError,
-    event: event_listener::Event,
+    event: Event,
 }
 
 impl Default for Completion {
@@ -81,7 +82,7 @@ impl Default for Completion {
             current_epoch: atomic::AtomicU64::new(0),
             durable_epoch: atomic::AtomicU64::new(0),
             error: AckError::default(),
-            event: event_listener::Event::new(),
+            event: Event::new(),
         }
     }
 }
@@ -268,7 +269,7 @@ impl Completion {
 pub struct AckTicket {
     epoch: TEpoch,
     completion: sync::Arc<Completion>,
-    listener: Option<event_listener::EventListener>,
+    listener: Option<EventListener>,
 }
 
 impl AckTicket {
@@ -306,6 +307,58 @@ impl AckTicket {
     #[inline(always)]
     pub const fn epoch(&self) -> TEpoch {
         self.epoch
+    }
+
+    /// Blocks the current thread unitl the [`AckTicket`] becomes durable
+    ///
+    /// If a durability error is reported before the epoch becomes durable, the corresponding
+    /// [`FrozenError`] is returned instead.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use frozen_core::ack::{AckTicket, Completion};
+    /// use std::{sync::Arc, thread, time};
+    ///
+    /// let completion = Arc::new(Completion::default());
+    /// let epoch = completion.increment_current_epoch();
+    /// let ticket = AckTicket::new(epoch, completion.clone());
+    ///
+    /// thread::spawn({
+    ///     let completion = completion.clone();
+    ///
+    ///     move || {
+    ///         thread::sleep(time::Duration::from_millis(10));
+    ///         completion.mark_epoch_as_durable(epoch);
+    ///         completion.notify_all_listeners();
+    ///     }
+    /// });
+    ///
+    /// assert_eq!(ticket.wait().unwrap(), epoch);
+    /// ```
+    #[inline(always)]
+    pub fn wait(&self) -> FrozenResult<TEpoch> {
+        loop {
+            if self.is_ready() {
+                return Ok(self.epoch);
+            }
+
+            if let Some(frozen_err) = self.completion.get_err() {
+                return Err(frozen_err);
+            }
+
+            let listener = self.completion.event.listen();
+
+            if self.is_ready() {
+                return Ok(self.epoch);
+            }
+
+            if let Some(err) = self.completion.get_err() {
+                return Err(err);
+            }
+
+            listener.wait();
+        }
     }
 
     #[inline]
@@ -525,6 +578,69 @@ mod tests {
             assert_eq!(futures::executor::block_on(ticket_1).expect("ticket_1 must complete"), 1);
             assert_eq!(futures::executor::block_on(ticket_2).expect("ticket_2 must complete"), 2);
             assert_eq!(futures::executor::block_on(ticket_3).expect("ticket_3 must complete"), 3);
+        }
+    }
+
+    mod ticket_wait {
+        use super::*;
+
+        #[test]
+        fn ok_wait_when_epoch_already_durable() {
+            let completion = sync::Arc::new(Completion::default());
+            completion.mark_epoch_as_durable(1);
+
+            let ticket = AckTicket::new(1, completion);
+            assert_eq!(ticket.wait().expect("ticket must complete"), 1);
+        }
+
+        #[test]
+        fn ok_wait_after_durability_progress() {
+            let completion = sync::Arc::new(Completion::default());
+            let ticket = AckTicket::new(1, completion.clone());
+
+            thread::spawn({
+                let completion = completion.clone();
+                move || {
+                    thread::sleep(time::Duration::from_millis(10));
+
+                    completion.mark_epoch_as_durable(1);
+                    completion.notify_all_listeners();
+                }
+            });
+
+            assert_eq!(ticket.wait().expect("ticket must complete"), 1);
+        }
+
+        #[test]
+        fn err_wait_when_error_is_present() {
+            let completion = sync::Arc::new(Completion::default());
+            let expected = FrozenError::new(0x10, 0x20, ErrCode::new(0x30, "io"), "failure");
+
+            completion.set_err(expected.clone());
+
+            let ticket = AckTicket::new(1, completion);
+            assert_eq!(ticket.wait().expect_err("ticket must fail"), expected);
+        }
+
+        #[test]
+        fn err_wait_when_error_arrives_later() {
+            let completion = sync::Arc::new(Completion::default());
+            let ticket = AckTicket::new(1, completion.clone());
+            let expected = FrozenError::new(0x10, 0x20, ErrCode::new(0x30, "io"), "failure");
+
+            thread::spawn({
+                let completion = completion.clone();
+                let expected = expected.clone();
+
+                move || {
+                    thread::sleep(time::Duration::from_millis(10));
+
+                    completion.set_err(expected);
+                    completion.notify_all_listeners();
+                }
+            });
+
+            assert_eq!(ticket.wait().expect_err("ticket must fail"), expected);
         }
     }
 }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -145,6 +145,23 @@ pub(in crate::fmmap) mod err {
 }
 
 /// Config for [`FrozenMMap`]
+///
+/// ## Example
+///
+/// ```
+/// use frozen_core::fmmap::FrozenMMapCfg;
+///
+/// let cfg = FrozenMMapCfg {
+///     module_id: 0,
+///     initial_count: 0x100,
+///     immediate_durability: false,
+///     flush_duration: std::time::Duration::from_millis(0x0A),
+/// };
+///
+/// assert_eq!(cfg.initial_count, 0x100);
+/// assert!(!cfg.immediate_durability);
+/// assert_eq!(cfg.flush_duration.as_millis(), 0x0A);
+/// ```
 #[derive(Debug, Clone)]
 pub struct FrozenMMapCfg {
     /// Identifier used for error propagation by [`frozen_core::error::FrozenError`]
@@ -249,6 +266,17 @@ where
     T: Sized + Send + Sync,
 {
     /// Memory space required for each slot of [`T`] in [`FrozenMMap`]
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use frozen_core::fmmap::FrozenMMap;
+    ///
+    /// assert_eq!(
+    ///     FrozenMMap::<u64>::SLOT_SIZE,
+    ///     std::mem::size_of::<u64>(),
+    /// );
+    /// ```
     pub const SLOT_SIZE: usize = std::mem::size_of::<T>();
 
     /// Create a new [`FrozenMMap`] instance w/ given [`FrozenMMapCfg`]

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -774,9 +774,7 @@ where
     /// ```
     pub fn delete(&mut self) -> FrozenResult<()> {
         // NOTE: we must broadcast that the close is happening to allow flusher tx to wrap up
-        self.core.dirty.store(false, atomic::Ordering::Release);
         self.core.closed.store(true, atomic::Ordering::Release);
-
         if let Some(handle) = self.flush_tx_handle.take() {
             let _ = handle.join();
         }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -317,7 +317,13 @@ where
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
-        let core = sync::Arc::new(Core::new(mmap, file, curr_length, total_slots));
+        let core = sync::Arc::new(Core::new(
+            mmap,
+            file,
+            curr_length,
+            total_slots,
+            cfg.immediate_durability,
+        ));
 
         let cloned_core = sync::Arc::clone(&core);
         let flush_tx_handle = match thread::Builder::new()
@@ -412,7 +418,13 @@ where
         let _ = err::MID.get_or_init(|| cfg.module_id);
 
         let mmap = unsafe { TMap::new(file.fd(), curr_length) }?;
-        let core = sync::Arc::new(Core::new(mmap, file, curr_length, total_slots));
+        let core = sync::Arc::new(Core::new(
+            mmap,
+            file,
+            curr_length,
+            total_slots,
+            cfg.immediate_durability,
+        ));
 
         let cloned_core = sync::Arc::clone(&core);
         let flush_tx_handle = match thread::Builder::new()
@@ -589,8 +601,11 @@ where
         f(ptr);
 
         self.core.dirty.store(true, atomic::Ordering::Release);
-        let epoch = self.core.completion.increment_current_epoch();
+        if self.core.immediate_durability {
+            self.core.cv.notify_one();
+        }
 
+        let epoch = self.core.completion.increment_current_epoch();
         Ok(ack::AckTicket::new(epoch, self.core.completion.clone()))
     }
 
@@ -1130,8 +1145,11 @@ impl<'a, T> FrozenMMapTransaction<'a, T> {
         }
 
         self.core.dirty.store(true, atomic::Ordering::Release);
-        let epoch = self.core.completion.increment_current_epoch();
+        if self.core.immediate_durability {
+            self.core.cv.notify_one();
+        }
 
+        let epoch = self.core.completion.increment_current_epoch();
         Ok(ack::AckTicket::new(epoch, self.core.completion.clone()))
     }
 }
@@ -1143,6 +1161,7 @@ struct Core {
     curr_length: usize,
     dirty: atomic::AtomicBool,
     io_lock: sync::RwLock<()>,
+    immediate_durability: bool,
     map: TMap,
     locks: Locks,
     lock: sync::Mutex<()>,
@@ -1155,11 +1174,18 @@ unsafe impl Send for Core {}
 unsafe impl Sync for Core {}
 
 impl Core {
-    fn new(map: TMap, file: FrozenFile, curr_length: usize, total_slots: usize) -> Self {
+    fn new(
+        map: TMap,
+        file: FrozenFile,
+        curr_length: usize,
+        total_slots: usize,
+        immediate_durability: bool,
+    ) -> Self {
         Self {
             map,
             file,
             curr_length,
+            immediate_durability,
             completion: sync::Arc::new(ack::Completion::default()),
             cv: sync::Condvar::new(),
             lock: sync::Mutex::new(()),

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -776,7 +776,6 @@ where
         // NOTE: we must broadcast that the close is happening to allow flusher tx to wrap up
         self.core.dirty.store(false, atomic::Ordering::Release);
         self.core.closed.store(true, atomic::Ordering::Release);
-        self.core.durable_cv.notify_one();
 
         if let Some(handle) = self.flush_tx_handle.take() {
             let _ = handle.join();
@@ -1166,7 +1165,6 @@ struct Core {
     locks: Locks,
     lock: sync::Mutex<()>,
     file: FrozenFile,
-    durable_cv: sync::Condvar,
     closed: atomic::AtomicBool,
 }
 
@@ -1191,7 +1189,6 @@ impl Core {
             lock: sync::Mutex::new(()),
             io_lock: sync::RwLock::new(()),
             locks: Locks::new(total_slots),
-            durable_cv: sync::Condvar::new(),
             dirty: atomic::AtomicBool::new(false),
             closed: atomic::AtomicBool::new(false),
         }

--- a/src/fmmap/mod.rs
+++ b/src/fmmap/mod.rs
@@ -43,7 +43,7 @@
 //! let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
 //! let _ = futures::executor::block_on(ticket).unwrap();
 //!
-//! let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
+//! let val = unsafe { mmap.read(0, |v| *v) };
 //! assert_eq!(val, 0xDEADC0DE);
 //!
 //! drop(mmap);
@@ -51,7 +51,7 @@
 //! let reopened = FrozenMMap::<u64>::new_grown(&path, cfg, 0x05).unwrap();
 //! assert_eq!(reopened.total_slots(), 0x0A + 0x05);
 //!
-//! let val = unsafe { reopened.read(0, |v| *v) }.unwrap();
+//! let val = unsafe { reopened.read(0, |v| *v) };
 //! assert_eq!(val, 0xDEADC0DE);
 //! ```
 
@@ -220,7 +220,7 @@ pub struct FrozenMMapCfg {
 /// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
 /// let _ = futures::executor::block_on(ticket).unwrap();
 ///
-/// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
+/// let val = unsafe { mmap.read(0, |v| *v) };
 /// assert_eq!(val, 0xDEADC0DE);
 ///
 /// drop(mmap);
@@ -228,7 +228,7 @@ pub struct FrozenMMapCfg {
 /// let reopened = FrozenMMap::<u64>::new_grown(&path, cfg, 0x05).unwrap();
 /// assert_eq!(reopened.total_slots(), 0x0A + 0x05);
 ///
-/// let val = unsafe { reopened.read(0, |v| *v) }.unwrap();
+/// let val = unsafe { reopened.read(0, |v| *v) };
 /// assert_eq!(val, 0xDEADC0DE);
 /// ```
 #[derive(Debug)]
@@ -304,7 +304,7 @@ where
     /// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
+    /// let val = unsafe { mmap.read(0, |v| *v) };
     /// assert_eq!(val, 0xDEADC0DE);
     /// ```
     pub fn new<P: AsRef<std::path::Path>>(path: P, cfg: FrozenMMapCfg) -> FrozenResult<Self> {
@@ -397,7 +397,7 @@ where
     /// let ticket = unsafe { mmap.write(0, |v| *v = 0xDEADC0DE) }.unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
+    /// let val = unsafe { mmap.read(0, |v| *v) };
     /// assert_eq!(val, 0xDEADC0DE);
     /// ```
     pub fn new_grown<P: AsRef<std::path::Path>>(
@@ -523,11 +523,11 @@ where
     /// let ticket = unsafe { mmap.write(0, |v| *v = 0x0A) }.unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let val = unsafe { mmap.read(0, |v| *v) }.unwrap();
+    /// let val = unsafe { mmap.read(0, |v| *v) };
     /// assert_eq!(val, 0x0A);
     /// ```
     #[inline(always)]
-    pub unsafe fn read<R>(&self, index: usize, f: impl FnOnce(*const T) -> R) -> FrozenResult<R> {
+    pub unsafe fn read<R>(&self, index: usize, f: impl FnOnce(*const T) -> R) -> R {
         let offset = Self::SLOT_SIZE * index;
         let _lock = self.core.locks.lock(index);
 
@@ -535,7 +535,7 @@ where
         // assumption of OS guarantees visibility)
 
         let ptr = unsafe { self.core.map.as_ptr(offset) };
-        Ok(f(ptr))
+        f(ptr)
     }
 
     /// Write/update a `T` at given `index` via callback (`f`)
@@ -578,7 +578,7 @@ where
     /// let ticket = unsafe {mmap.write(1, |v| *v = 0x2B) }.unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let val = unsafe { mmap.read(1, |v| *v) }.unwrap();
+    /// let val = unsafe { mmap.read(1, |v| *v) };
     /// assert_eq!(val, 0x2B);
     /// ```
     #[inline(always)]
@@ -725,8 +725,8 @@ where
     /// let ticket = tx.commit().unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-    /// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
+    /// let v0 = unsafe { mmap.read(0, |v| *v) };
+    /// let v1 = unsafe { mmap.read(1, |v| *v) };
     ///
     /// assert_eq!((v0, v1), (0x0A, 0x14));
     /// ```
@@ -1000,9 +1000,9 @@ fn bg_flush_thread(core: sync::Arc<Core>, flush_duration: time::Duration) {
 /// let ticket = tx.commit().unwrap();
 /// let _ = futures::executor::block_on(ticket).unwrap();
 ///
-/// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-/// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
-/// let v2 = unsafe { mmap.read(2, |v| *v).unwrap() };
+/// let v0 = unsafe { mmap.read(0, |v| *v) };
+/// let v1 = unsafe { mmap.read(1, |v| *v) };
+/// let v2 = unsafe { mmap.read(2, |v| *v) };
 ///
 /// assert_eq!((v0, v1, v2), (0x0A, 0x14, 0x18));
 /// ```
@@ -1054,9 +1054,9 @@ impl<'a, T> FrozenMMapTransaction<'a, T> {
     /// let ticket = tx.commit().unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-    /// let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
-    /// let v2 = unsafe { mmap.read(2, |v| *v).unwrap() };
+    /// let v0 = unsafe { mmap.read(0, |v| *v) };
+    /// let v1 = unsafe { mmap.read(1, |v| *v) };
+    /// let v2 = unsafe { mmap.read(2, |v| *v) };
     ///
     /// assert_eq!((v0, v1, v2), (0x0A, 0x0B, 0x0C));
     /// ```
@@ -1119,8 +1119,8 @@ impl<'a, T> FrozenMMapTransaction<'a, T> {
     /// let ticket = tx.commit().unwrap();
     /// let _ = futures::executor::block_on(ticket).unwrap();
     ///
-    /// let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-    /// let v1 = unsafe { mmap.read(2, |v| *v).unwrap() };
+    /// let v0 = unsafe { mmap.read(0, |v| *v) };
+    /// let v1 = unsafe { mmap.read(2, |v| *v) };
     ///
     /// assert_eq!((v0, v1), (0x0A, 0x0C));
     /// ```
@@ -1400,7 +1400,7 @@ mod tests {
 
             {
                 let mmap = FrozenMMap::<u64>::new(&path, cfg.clone()).unwrap();
-                let val = unsafe { mmap.read(0, |byte| *byte).unwrap() };
+                let val = unsafe { mmap.read(0, |byte| *byte) };
                 assert_eq!(val, VAL);
             }
         }
@@ -1569,7 +1569,7 @@ mod tests {
                 let mmap = FrozenMMap::<u64>::new_grown(&path, cfg.clone(), 0x10).unwrap();
                 unsafe { mmap.write(0, |v| *v = 0xBB).unwrap() };
 
-                let val = unsafe { mmap.read(0, |v| *v).unwrap() };
+                let val = unsafe { mmap.read(0, |v| *v) };
                 assert_eq!(val, 0xBB);
             }
         }
@@ -1592,11 +1592,11 @@ mod tests {
 
             let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
 
-            let base = unsafe { mmap.read(0, |v| *v).unwrap() };
+            let base = unsafe { mmap.read(0, |v| *v) };
             assert_eq!(base, 1);
 
             let last_idx = mmap.total_slots() - 1;
-            let last = unsafe { mmap.read(last_idx, |v| *v).unwrap() };
+            let last = unsafe { mmap.read(last_idx, |v| *v) };
             assert_eq!(last, 3);
         }
 
@@ -1629,7 +1629,7 @@ mod tests {
             assert!(durable_epoch >= ticket_epoch);
 
             // read + verify
-            let val = unsafe { mmap.read(0, |ptr| *ptr).unwrap() };
+            let val = unsafe { mmap.read(0, |ptr| *ptr) };
             assert_eq!(val, VAL);
         }
 
@@ -1640,7 +1640,7 @@ mod tests {
             let mmap = FrozenMMap::<u64>::new(path, cfg).unwrap();
 
             unsafe { mmap.write(0, |ptr| *ptr = VAL).unwrap() };
-            let val = unsafe { mmap.read(0, |ptr| *ptr).unwrap() };
+            let val = unsafe { mmap.read(0, |ptr| *ptr) };
             assert_eq!(val, VAL);
         }
     }
@@ -1667,9 +1667,9 @@ mod tests {
 
             assert!(durable_epoch >= ticket_epoch);
 
-            let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-            let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
-            let v2 = unsafe { mmap.read(2, |v| *v).unwrap() };
+            let v0 = unsafe { mmap.read(0, |v| *v) };
+            let v1 = unsafe { mmap.read(1, |v| *v) };
+            let v2 = unsafe { mmap.read(2, |v| *v) };
 
             assert_eq!((v0, v1, v2), (1, 2, 3));
         }
@@ -1749,8 +1749,8 @@ mod tests {
             }
 
             for i in 0..2 {
-                let v0 = unsafe { mmap.read(i * 2, |v| *v).unwrap() };
-                let v1 = unsafe { mmap.read(i * 2 + 1, |v| *v).unwrap() };
+                let v0 = unsafe { mmap.read(i * 2, |v| *v) };
+                let v1 = unsafe { mmap.read(i * 2 + 1, |v| *v) };
 
                 assert_eq!((v0, v1), (i as u64, i as u64));
             }
@@ -1780,7 +1780,7 @@ mod tests {
 
             assert!(durable_epoch >= ticket_epoch);
 
-            let val = unsafe { mmap.read(0, |v| *v).unwrap() };
+            let val = unsafe { mmap.read(0, |v| *v) };
             assert_eq!(val, 2);
         }
 
@@ -1808,8 +1808,8 @@ mod tests {
             {
                 let mmap = FrozenMMap::<u64>::new(&path, cfg).unwrap();
 
-                let v0 = unsafe { mmap.read(0, |v| *v).unwrap() };
-                let v1 = unsafe { mmap.read(1, |v| *v).unwrap() };
+                let v0 = unsafe { mmap.read(0, |v| *v) };
+                let v1 = unsafe { mmap.read(1, |v| *v) };
 
                 assert_eq!((v0, v1), (0x3A, 0x54));
             }
@@ -1868,7 +1868,7 @@ mod tests {
                 h.join().unwrap();
             }
 
-            let val = unsafe { mmap.read(0, |v| *v).unwrap() };
+            let val = unsafe { mmap.read(0, |v| *v) };
             assert_eq!(val, 2);
         }
     }
@@ -1886,12 +1886,12 @@ mod tests {
 
             let t1 = {
                 let mmap = mmap.clone();
-                thread::spawn(move || unsafe { mmap.read(0, |v| *v).unwrap() })
+                thread::spawn(move || unsafe { mmap.read(0, |v| *v) })
             };
 
             let t2 = {
                 let mmap = mmap.clone();
-                thread::spawn(move || unsafe { mmap.read(1, |v| *v).unwrap() })
+                thread::spawn(move || unsafe { mmap.read(1, |v| *v) })
             };
 
             assert_eq!(t1.join().unwrap(), 0x10);
@@ -1916,7 +1916,7 @@ mod tests {
                 for i in 0..2usize {
                     let mmap = mmap.clone();
                     handles.push(thread::spawn(move || {
-                        let _ = unsafe { mmap.read(i, |v| *v).unwrap() };
+                        let _ = unsafe { mmap.read(i, |v| *v) };
                     }));
                 }
 
@@ -1930,14 +1930,14 @@ mod tests {
                 assert_eq!(mmap.total_slots(), INIT_SLOTS + 0x10);
 
                 for i in 0..2u64 {
-                    let val = unsafe { mmap.read(i as usize, |v| *v).unwrap() };
+                    let val = unsafe { mmap.read(i as usize, |v| *v) };
                     assert_eq!(val, i + 1);
                 }
 
                 let idx = mmap.total_slots() - 1;
                 unsafe { mmap.write(idx, |v| *v = 0xDEAD).unwrap() };
 
-                let val = unsafe { mmap.read(idx, |v| *v).unwrap() };
+                let val = unsafe { mmap.read(idx, |v| *v) };
                 assert_eq!(val, 0xDEAD);
             }
         }


### PR DESCRIPTION
# Release of `0.0.30`

## Changelog

- Updated api signature of `FrozenMMap::read()` (#75)
- Fixed dishonore of `immediate_durability` in `FrozenMMapCfg` (#76)
- Impl of `AckTicket::wait()` for internal blocking (#77)
- Remove the stale `durable_cv` from `FrozenMMap -> Core` (#78)
- Fixed `FrozenMMap::delete()` to avoid incorrectly updating `dirty` flag (#79)

## Ready?

- [x] All unit tests passing
- [x] All doctests passing
- [x] No lints or warnings
- [x] Updated README
- [x] Updated CHANGELOG
- [x] Version bump

## Summery

- Closes #75
- Fixes #76
- Closes #77 
- Closes #78
- Fixes #79